### PR TITLE
wip: workflows with long lived clusters only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2.0
+version: 2.1
 
 orbs:
   codacy: codacy/base@1.0.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2.1
+version: 2.0
 
 orbs:
   codacy: codacy/base@1.0.1
@@ -21,74 +21,6 @@ jobs:
       - deploy:
           command: make -C .doks/ deploy_to_doks
 
-  deploy_to_doks_nightly:
-    docker:
-      - image: codacy/ci-do:0.2.3
-    environment:
-      DOKS_CLUSTER_NAME: codacy-doks-cluster-nightly
-    working_directory: ~/workdir/
-    steps:
-      - attach_workspace:
-          at: ~/
-      - run:
-          name: "Helm lint"
-          command: helm lint codacy/
-      - run:
-          name: "Setup DO Credentials"
-          command: doctl auth init -t $DO_TOKEN &>/dev/null
-      - deploy:
-          command: make -C .doks/ deploy_to_doks
-
-  validate_deployment_status:
-    docker:
-      - image: codacy/ci-do:0.2.3
-    environment:
-      DOKS_CLUSTER_NAME: codacy-doks-cluster-nightly
-    working_directory: ~/workdir/
-    steps:
-      - attach_workspace:
-          at: ~/
-      - run:
-          name: "Setup DO Credentials"
-          command: doctl auth init -t $DO_TOKEN &>/dev/null
-      - run:
-          name: "Validate deployment status"
-          command: |
-            set -e
-            doctl kubernetes cluster kubeconfig save "$DOKS_CLUSTER_NAME" --set-current-context
-            DEPLOYMENTS=$(kubectl get deployments -n codacy | awk '{print "deployment/"$1}' | tail -n +2 )
-            for DEPLOYMENT in ${DEPLOYMENTS[@]}
-            do
-                kubectl rollout status -n codacy --watch "$DEPLOYMENT"
-            done
-      - persist_to_workspace:
-          root: ~/
-          paths:
-            - workdir
-
-  start_nightly_cluster:
-    docker:
-      - image: codacy/ci-do:0.2.3
-    environment:
-      DOKS_CLUSTER_NAME: codacy-doks-cluster-nightly
-      DO_TF_WORKSPACE: nightly
-    working_directory: ~/workdir/
-    steps:
-      - checkout
-      - run:
-          name: "Setup DO Credentials"
-          command: doctl auth init -t $DO_TOKEN &>/dev/null
-      - run:
-          name: "Start Cluster"
-          command: make -C ./.doks/doks-cluster cluster
-      - run:
-          name: "Populate Cluster"
-          command: make -C ./.doks/doks-cluster populate_cluster
-      - persist_to_workspace:
-          root: ~/
-          paths:
-            - workdir
-
   update_versions:
     docker:
       - image: codacy/ci-do:0.2.3
@@ -106,6 +38,10 @@ jobs:
           root: ~/
           paths:
             - workdir
+      - run:
+          name: "Destroy Cluster"
+          command: make -C ./.doks/doks-cluster destroy_cluster
+          when: on_fail
 
   get_changelogs:
     docker:
@@ -130,7 +66,7 @@ jobs:
       - store_artifacts:
           path: ~/workdir/changelogs
 
-  destroy_nightly_cluster:
+  manual_qa_hold:
     docker:
       - image: codacy/ci-do:0.2.3
     environment:
@@ -142,9 +78,39 @@ jobs:
       - run:
           name: "Setup DO Credentials"
           command: doctl auth init -t $DO_TOKEN &>/dev/null
-      - deploy:
+          when: on_fail
+      - run:
           name: "Destroy Cluster"
           command: make -C ./.doks/doks-cluster destroy_cluster
+          when: on_fail
+
+  helm_push_incubator:
+    docker:
+      - image: codacy/ci-do:0.2.3
+    environment:
+      DOKS_CLUSTER_NAME: codacy-doks-cluster-nightly
+      DO_TF_WORKSPACE: nightly
+    working_directory: ~/workdir/
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: "Install requirements"
+          command: |
+            apk add --no-cache python3
+            pip3 install ytool
+      - run:
+          name: Set image tag and version using semver
+          command: |
+            ytool -s appVersion "$(cat .version)" -s version "$(cat .version)" -f "./codacy/Chart.yaml" -e
+            git --no-pager diff --no-color
+      - run:
+          name: Push to charts museum
+          command: |
+            helm dep up ./codacy
+            echo "Adding 'https://charts.codacy.com/incubator'"
+            helm repo add --username "${CHARTS_REPO_USER}" --password "${CHARTS_REPO_PASS}" codacy https://charts.codacy.com/incubator
+            helm push ./codacy codacy
 
 workflows:
   branch_checks:
@@ -172,40 +138,67 @@ workflows:
               only:
                 - master
 
-  perform_nightly_release:
-    triggers:
-       - schedule:
-           cron: "0 0 * * 1-5"
-           filters:
-             branches:
-               only:
-                 - master
+  create_cluster_pipeline:
     jobs:
-      - start_nightly_cluster:
+      - codacy/doks_cluster_start:
           context: CodacyDO
+          filters:
+            branches:
+              only:
+                - master
+          cluster_name: "codacy-doks-cluster-nightly"
+          kubernetes_version: "1.15"
+          tf_workspace: "nightly"
+          destroy_cluster: true
+          start_cluster_command: "make -C ./.doks/doks-cluster cluster; make -C ./.doks/doks-cluster populate_cluster"
+          destroy_cluster_command: "make -C ./.doks/doks-cluster destroy_cluster"
+
+  release_pipeline:
+    jobs:
+      - codacy/doks_cluster_purge:
+          context: CodacyDO
+          filters:
+            branches:
+              only:
+                - master
+          cluster_name: "codacy-doks-cluster-nightly"
       - update_versions:
           context: CodacyDO
           requires:
-            - start_nightly_cluster
+            - codacy/doks_cluster_purge
       - get_changelogs:
           context: CodacyDO
           requires:
             - update_versions
-      - deploy_to_doks_nightly:
-          context: CodacyDO
+      - codacy/doks_deploy:
+          cluster_name: "codacy-doks-cluster-nightly"
+          deployment_command: "make -C .doks/ deploy_to_doks"
           requires:
-            - start_nightly_cluster
-            - update_versions
             - get_changelogs
-      - validate_deployment_status:
+      - codacy/doks_validate:
+          context: CodacyDO
+          requires: 
+            - codacy/doks_deploy
+      - helm_push_incubator:
           context: CodacyDO
           requires:
-            - deploy_to_doks_nightly
+            - validate_deployment_status
       - manual_qa_hold:
           type: approval
           requires:
-           - validate_deployment_status
-      - destroy_nightly_cluster:
+            - helm_push_incubator
+      - codacy/tag_version:
+          name: tag_version
           context: CodacyDO
           requires:
             - manual_qa_hold
+      - codacy/helm_promote:
+          name: promote_chart_to_stable
+          context: CodacyHelm
+          chart_name: codacy
+          source_charts_repo_url: "https://charts.codacy.com/incubator"
+          target_charts_repo_url: "https://charts.codacy.com/stable"
+          requires:
+            - tag_version
+      
+      

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/base@dev:1.1.0-featuredigitaloceanorbs.df72383
+  codacy: codacy/base@dev:1.1.0-featuredigitaloceanorbs.236ac9f
 
 jobs:
   deploy_to_doks:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/base@dev:1.1.0-featuredigitaloceanorbs.16684c6
+  codacy: codacy/base@dev:1.1.0-featuredigitaloceanorbs.a44d917
 
 jobs:
   deploy_to_doks:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/base@dev:1.1.0-featuredigitaloceanorbs.236ac9f
+  codacy: codacy/base@dev:1.1.0-featuredigitaloceanorbs.310f27d
 
 jobs:
   deploy_to_doks:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,6 +150,8 @@ workflows:
           destroy_cluster: true
           start_cluster_command: "make -C ./.doks/doks-cluster cluster; make -C ./.doks/doks-cluster populate_cluster"
           destroy_cluster_command: "make -C ./.doks/doks-cluster destroy_cluster"
+          requires:
+            - codacy/checkout_and_version
 
   release_pipeline:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/base@dev:1.1.0-featuredigitaloceanorbs.715001f
+  codacy: codacy/base@dev:1.1.0-featuredigitaloceanorbs.fa65e0a
 
 jobs:
   deploy_to_doks:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,8 +148,8 @@ workflows:
           kubernetes_version: "1.15"
           tf_workspace: "nightly"
           destroy_cluster: true
-          start_cluster_command: "make -C ./workdir/.doks/doks-cluster cluster; make -C ./.doks/doks-cluster populate_cluster"
-          destroy_cluster_command: "make -C ./workdir/.doks/doks-cluster destroy_cluster"
+          start_cluster_command: make -C ./workdir/.doks/doks-cluster cluster; make -C ./.doks/doks-cluster populate_cluster
+          destroy_cluster_command: make -C ./workdir/.doks/doks-cluster destroy_cluster
           requires:
             - codacy/checkout_and_version
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/base@dev:1.1.0-featuredigitaloceanorbs.a44d917
+  codacy: codacy/base@dev:1.1.0-featuredigitaloceanorbs.0782662
 
 jobs:
   deploy_to_doks:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/base@dev:1.1.0-featuredigitaloceanorbs.526f0b8
+  codacy: codacy/dev:1.1.0-featuredigitaloceanorbs.715001f
 
 jobs:
   deploy_to_doks:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,8 +148,8 @@ workflows:
           kubernetes_version: "1.15"
           tf_workspace: "nightly"
           destroy_cluster: true
-          start_cluster_command: "make -C ./.doks/doks-cluster cluster; make -C ./.doks/doks-cluster populate_cluster"
-          destroy_cluster_command: "make -C ./.doks/doks-cluster destroy_cluster"
+          start_cluster_command: "make -C ./workdir/.doks/doks-cluster cluster; make -C ./.doks/doks-cluster populate_cluster"
+          destroy_cluster_command: "make -C ./workdir/.doks/doks-cluster destroy_cluster"
           requires:
             - codacy/checkout_and_version
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/base@1.0.1
+  codacy: codacy/base@dev:1.1.0-featuredigitaloceanorbs.526f0b8
 
 jobs:
   deploy_to_doks:
@@ -142,10 +142,6 @@ workflows:
     jobs:
       - codacy/checkout_and_version:
           context: CodacyDO
-          filters:
-            branches:
-              only:
-                - master
       - codacy/doks_cluster_start:
           context: CodacyDO
           cluster_name: "codacy-doks-cluster-nightly"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,6 +140,8 @@ workflows:
 
   create_cluster_pipeline:
     jobs:
+      - codacy/checkout_and_version:
+          context: CodacyDO
       - codacy/doks_cluster_start:
           context: CodacyDO
           filters:
@@ -155,12 +157,14 @@ workflows:
 
   release_pipeline:
     jobs:
-      - codacy/doks_cluster_purge:
+      - codacy/checkout_and_version:
           context: CodacyDO
           filters:
-            branches:
-              only:
-                - master
+              branches:
+                only:
+                  - master
+      - codacy/doks_cluster_purge:
+          context: CodacyDO
           cluster_name: "codacy-doks-cluster-nightly"
       - update_versions:
           context: CodacyDO

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,8 +148,8 @@ workflows:
           kubernetes_version: "1.15"
           tf_workspace: "nightly"
           destroy_cluster: true
-          start_cluster_command: make -C ./workdir/.doks/doks-cluster cluster; make -C ./.doks/doks-cluster populate_cluster
-          destroy_cluster_command: make -C ./workdir/.doks/doks-cluster destroy_cluster
+          start_cluster_command: make -C ./.doks/doks-cluster cluster; make -C ./.doks/doks-cluster populate_cluster
+          destroy_cluster_command: make -C ./.doks/doks-cluster destroy_cluster
           requires:
             - codacy/checkout_and_version
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,12 +142,12 @@ workflows:
     jobs:
       - codacy/checkout_and_version:
           context: CodacyDO
-      - codacy/doks_cluster_start:
-          context: CodacyDO
           filters:
             branches:
               only:
                 - master
+      - codacy/doks_cluster_start:
+          context: CodacyDO
           cluster_name: "codacy-doks-cluster-nightly"
           kubernetes_version: "1.15"
           tf_workspace: "nightly"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,7 +186,7 @@ workflows:
       - helm_push_incubator:
           context: CodacyDO
           requires:
-            - validate_deployment_status
+            - codacy/doks_validate
       - manual_qa_hold:
           type: approval
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/base@dev:1.1.0-featuredigitaloceanorbs.fa65e0a
+  codacy: codacy/base@dev:1.1.0-featuredigitaloceanorbs.df72383
 
 jobs:
   deploy_to_doks:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/dev:1.1.0-featuredigitaloceanorbs.715001f
+  codacy: codacy/base@dev:1.1.0-featuredigitaloceanorbs.715001f
 
 jobs:
   deploy_to_doks:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/base@dev:1.1.0-featuredigitaloceanorbs.310f27d
+  codacy: codacy/base@dev:1.1.0-featuredigitaloceanorbs.16684c6
 
 jobs:
   deploy_to_doks:

--- a/.doks/doks-cluster/Makefile
+++ b/.doks/doks-cluster/Makefile
@@ -52,7 +52,7 @@ populate_cluster: setup_vars create_terraformrc
 
 .PHONY: remove_codacy
 remove_codacy:
-	helm delete --purge codacy
+	set +e; helm delete --purge codacy; set -e;
 	kubectl delete pvc -n codacy $(shell kubectl get pvc -n codacy -o jsonpath='{.items[*].metadata.name}') &
 	kubectl delete pods -n codacy $(shell kubectl get pods -n codacy -o jsonpath='{.items[*].metadata.name}') --force --grace-period=0 --ignore-not-found=true &
 


### PR DESCRIPTION
Circleci doesn't allow us to do conditional workflows. This means that we can no do a couple of things that would be a requirement for the manual QA approval step, such as disposing of the cluster if QA does not approve of the release.

Therefore, we have decided to move to long lived clusters only for all workflows.