### PR TITLE
Use separate namespaces for dev and non-dev environments (release and nightly builds)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,10 +9,12 @@ references:
     docker:
       - image: codacy/ci-do:0.2.3
     working_directory: ~/workdir/
-
+  
+    # doks node types can be found here https://developers.digitalocean.com/documentation/v2/
   dev_environment: &dev_environment
     DOKS_CLUSTER_NAME: codacy-doks-cluster-dev
     DO_TF_WORKSPACE: dev
+    NAMESPACE: codacy
     NODE_TYPE: s-20vcpu-96gb
     K8S_VERSION: 1.14
     NUM_NODES: 5
@@ -20,6 +22,7 @@ references:
   nightly_environment: &nightly_environment
     DOKS_CLUSTER_NAME: codacy-doks-cluster-release
     DO_TF_WORKSPACE: release
+    NAMESPACE: codacy-release
     NODE_TYPE: s-20vcpu-96gb
     K8S_VERSION: 1.15
     NUM_NODES: 4

--- a/.doks/Makefile
+++ b/.doks/Makefile
@@ -6,7 +6,7 @@ deploy_to_doks:
 
 	helm upgrade --install codacy ../codacy/ \
 	 	-f values.yaml \
-	 	--namespace codacy \
+	 	--namespace ${NAMESPACE} \
 		--set global.imagePullSecrets[0].name=docker-credentials \
 		--set global.play.cryptoSecret=$${SHARED_PLAY_CRYPTO_SECRET} \
 		--set global.filestore.contentsSecret=$${SHARED_PLAY_CRYPTO_SECRET} \

--- a/.doks/doks-cluster/Makefile
+++ b/.doks/doks-cluster/Makefile
@@ -52,9 +52,9 @@ populate_cluster: setup_vars create_terraformrc
 
 .PHONY: remove_codacy
 remove_codacy:
-	helm delete --purge codacy
-	kubectl delete pvc -n codacy $(shell kubectl get pvc -n codacy -o jsonpath='{.items[*].metadata.name}') &
-	kubectl delete pods -n codacy $(shell kubectl get pods -n codacy -o jsonpath='{.items[*].metadata.name}') --force --grace-period=0 --ignore-not-found=true &
+	helm delete --purge ${NAMESPACE}
+	kubectl delete pvc -n ${NAMESPACE} $(shell kubectl get pvc -n ${NAMESPACE} -o jsonpath='{.items[*].metadata.name}') &
+	kubectl delete pods -n ${NAMESPACE} $(shell kubectl get pods -n ${NAMESPACE} -o jsonpath='{.items[*].metadata.name}') --force --grace-period=0 --ignore-not-found=true &
 
 .PHONY: destroy_cluster
 destroy_cluster: setup_vars create_terraformrc set_cluster_context remove_codacy


### PR DESCRIPTION
the goal is to reduce the number of clusters and avoid conflicts between helm deployments running on the same cluster.
For example, the merge-to-dev and the hourly workflows will both point to the dev cluster. We do not want the hourly deployment interfering with what has been deployed to the same cluster.