### PR TITLE
fix: nfserverprovisioner do not change storage class name

### DIFF
--- a/.doks/Makefile
+++ b/.doks/Makefile
@@ -14,8 +14,7 @@ deploy_to_doks:
 		--set global.cacheSecret=$${SHARED_PLAY_CRYPTO_SECRET} \
 		--set codacy-api.config.license=$${CODACY_LICENSE} \
 		--set global.codacy.url="http://k8s.dev.codacy.org" \
-		--set global.codacy.backendUrl="http://k8s.dev.codacy.org" \
-		--set listener.nfsserverprovisioner.storageClass.name="${RELEASE_NAME}-listener-cache-class"
+		--set global.codacy.backendUrl="http://k8s.dev.codacy.org"
 
 .PHONY: set_cluster_context
 set_cluster_context: 


### PR DESCRIPTION
We need this functionality to be able to install 2 codacy releases on the same cluster.
However, since the dev cluster is longlived, this change will clash with what currently exists there.
I am removing this parameter just so we can first fix dev and master, and return to this issue later.