### PR TITLE
fix broken rotate pods

### DIFF
--- a/.doks/Makefile
+++ b/.doks/Makefile
@@ -40,7 +40,7 @@ deploy_to_doks_from_chartmuseum: set_cluster_context
 
 define rotate_pod
 kubectl patch deployment $(strip $(1)) -n ${NAMESPACE} -p '{"spec":{"template":{"metadata":{"annotations":{"date": "'$(shell date +'%Y-%m-%dT%H:%M:%S')'" }}}}}';
-kubectl rollout status "deployment/$(strip $(1))";
+kubectl rollout status "deployment/$(strip $(1))" -n ${NAMESPACE};
 endef
 
 .PHONY: rotate_pods


### PR DESCRIPTION
needs -n for namespace otherwise all rollout status commands fail.