### PR TITLE
fix: use semantic versions for all components

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -384,12 +384,15 @@ jobs:
           command: |
             git config --global user.email "circleci@codacy.com"
             git config --global user.name "codacycircleci"
+            ssh-keyscan github.com >> ~/.ssh/known_hosts
+            ssh-keyscan bitbucket.org >> ~/.ssh/known_hosts
       - deploy:
           name: Commit and push requirements.lock file
           command: |
+            BRANCH=$(git rev-parse --abbrev-ref HEAD)
             git add codacy/requirements.lock
             git commit -m "[ci skip] nightly requirements.lock commit."
-            git push
+            git push --set-upstream origin $BRANCH
       - <<: *persist_to_workspace
 
 workflows:

--- a/codacy/requirements.lock
+++ b/codacy/requirements.lock
@@ -13,39 +13,39 @@ dependencies:
   version: 0.3.0
 - name: portal
   repository: https://charts.codacy.com/stable
-  version: 4.32.2
+  version: 4.32.3
 - name: ragnaros
   repository: https://charts.codacy.com/stable
-  version: 15.1.3
+  version: 15.2.1
 - name: activities
   repository: https://charts.codacy.com/stable
   version: 1.2.0
 - name: remote-provider-service
   repository: https://charts.codacy.com/stable
-  version: 2.43.0
+  version: 2.44.0
 - name: hotspots-api
   repository: https://charts.codacy.com/stable
-  version: 1.3.0
+  version: 1.4.1
 - name: hotspots-worker
   repository: https://charts.codacy.com/stable
-  version: 1.3.0
+  version: 1.4.1
 - name: listener
   repository: https://charts.codacy.com/stable
-  version: 7.9.0
+  version: 7.10.0
 - name: core
   repository: https://charts.codacy.com/stable
-  version: 2.13.0
+  version: 2.13.1
 - name: engine
   repository: https://charts.codacy.com/stable
-  version: 5.56.0
+  version: 5.57.0
 - name: codacy-api
   repository: https://charts.codacy.com/stable
-  version: 4.124.1
+  version: 4.127.0
 - name: worker-manager
   repository: https://charts.codacy.com/stable
-  version: 8.10.0
+  version: 8.12.0
 - name: crow
   repository: https://charts.codacy.com/stable
   version: 4.4.0
-digest: sha256:f2a6f3b7773f8de0b938f3aae1c8639ef5db3f79c0c4b2fa53759d01e637a9b2
-generated: "2020-01-09T15:18:50.58016667Z"
+digest: sha256:24492b48db45a058453ddf15a1b36332856dacacea40d800902953f764cd62e2
+generated: "2020-01-13T13:27:26.69205Z"

--- a/codacy/requirements.lock
+++ b/codacy/requirements.lock
@@ -19,7 +19,7 @@ dependencies:
   version: 15.1.3
 - name: activities
   repository: https://charts.codacy.com/stable
-  version: 1.1.0
+  version: 1.2.0
 - name: remote-provider-service
   repository: https://charts.codacy.com/stable
   version: 2.43.0
@@ -48,4 +48,4 @@ dependencies:
   repository: https://charts.codacy.com/stable
   version: 4.4.0
 digest: sha256:f2a6f3b7773f8de0b938f3aae1c8639ef5db3f79c0c4b2fa53759d01e637a9b2
-generated: "2020-01-08T09:07:54.487184Z"
+generated: "2020-01-09T15:18:50.58016667Z"

--- a/codacy/requirements.yaml
+++ b/codacy/requirements.yaml
@@ -25,12 +25,12 @@ dependencies:
   git: git@github.com:codacy/kube-fluentd-operator.git
 
 - name: portal
-  version: 4.32.2
+  version: ^4.32.2
   repository: https://charts.codacy.com/stable
   git: git@bitbucket.org:qamine/portal.git
 
 - name: ragnaros
-  version: 15.2.1
+  version: ^15.2.1
   repository: https://charts.codacy.com/stable
   git: git@bitbucket.org:qamine/ragnaros.git
 
@@ -40,42 +40,42 @@ dependencies:
   git: git@bitbucket.org:qamine/codacy-activities.git
 
 - name: remote-provider-service
-  version: 2.43.0
+  version: ^2.43.0
   repository: https://charts.codacy.com/stable
   git: git@bitbucket.org:qamine/remote-provider-service.git
 
 - name: hotspots-api
-  version: 1.3.0
+  version: ^1.3.0
   repository: https://charts.codacy.com/stable
   git: git@bitbucket.org:qamine/hotspots-api.git
 
 - name: hotspots-worker
-  version: 1.3.0
+  version: ^1.3.0
   repository: https://charts.codacy.com/stable
   git: git@bitbucket.org:qamine/hotspots-worker.git
 
 - name: listener
-  version: 7.9.0
+  version: ^7.9.0
   repository: https://charts.codacy.com/stable
   git: git@bitbucket.org:qamine/repository-listener.git
 
 - name: core
-  version: 2.13.0
+  version: ^2.13.0
   repository: https://charts.codacy.com/stable
   git: git@bitbucket.org:qamine/codacy-core.git
 
 - name: engine
-  version: 5.56.0
+  version: ^5.56.0
   repository: https://charts.codacy.com/stable
   git: git@bitbucket.org:qamine/codacy-worker.git
 
 - name: codacy-api
-  version: 4.124.1
+  version: ^4.124.1
   repository: https://charts.codacy.com/stable
   git: git@bitbucket.org:qamine/codacy-website.git
 
 - name: worker-manager
-  version: 8.11.2
+  version: ^8.11.2
   repository: https://charts.codacy.com/stable
   git: git@bitbucket.org:qamine/worker-manager.git
 


### PR DESCRIPTION
We want to go back to using regexes for versions.
The reason is that our hourly QA tests and hourly and nightly rollout validations will need to deploy the latest versions of each component to know whether there have been any breaking changes.
