### PR TITLE
fix: update worker version on release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -552,6 +552,10 @@ workflows:
           filters:
             tags:
               only: /^release-.*/
+      - update_versions:
+          context: CodacyDO
+          requires:
+            - get_changelogs
       - deploy_to_doks_release:
           context: CodacyDO
           requires:


### PR DESCRIPTION
By having a dedicated release branch, we can safely call update_versions on release as the versions on the requirements file will definitely be frozen versions :)