### PR TITLE
push to 'hourly' namespace on merge to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -521,7 +521,7 @@ workflows:
           filters:
               branches:
                 only:
-                  - feature/hourly_tests
+                  - master
       - codacy/helm_aws:
           name: helm_lint
           cmd: helm lint codacy/

--- a/codacy/requirements.lock
+++ b/codacy/requirements.lock
@@ -13,16 +13,16 @@ dependencies:
   version: 0.3.0
 - name: portal
   repository: https://charts.codacy.com/stable
-  version: 5.0.0
+  version: 5.1.1
 - name: ragnaros
   repository: https://charts.codacy.com/stable
-  version: 15.2.2
+  version: 16.0.0
 - name: activities
   repository: https://charts.codacy.com/stable
   version: 1.3.0
 - name: remote-provider-service
   repository: https://charts.codacy.com/stable
-  version: 2.44.0
+  version: 2.45.1
 - name: hotspots-api
   repository: https://charts.codacy.com/stable
   version: 1.4.1
@@ -37,15 +37,15 @@ dependencies:
   version: 3.0.0
 - name: engine
   repository: https://charts.codacy.com/stable
-  version: 6.0.0
+  version: 6.1.1
 - name: codacy-api
   repository: https://charts.codacy.com/stable
-  version: 5.3.1
+  version: 5.8.0
 - name: worker-manager
   repository: https://charts.codacy.com/stable
-  version: 9.0.1
+  version: 9.0.2
 - name: crow
   repository: https://charts.codacy.com/stable
   version: 4.4.0
-digest: sha256:7a2d0f73663f5f385b0abfa2e87b6903f0515d29c9078a0d5cb61a744cfd9ec6
-generated: "2020-01-20T11:25:45.929391Z"
+digest: sha256:ff354bced2d0cfb2e188686a787cf4013c0d3915865ef3d2215c8ad79a0ab48b
+generated: "2020-01-27T11:03:04.343815Z"

--- a/codacy/requirements.yaml
+++ b/codacy/requirements.yaml
@@ -25,12 +25,12 @@ dependencies:
   git: git@github.com:codacy/kube-fluentd-operator.git
 
 - name: portal
-  version: 5.0.0
+  version: 5.1.1
   repository: https://charts.codacy.com/stable
   git: git@bitbucket.org:qamine/portal.git
 
 - name: ragnaros
-  version: 15.2.2
+  version: 16.0.0
   repository: https://charts.codacy.com/stable
   git: git@bitbucket.org:qamine/ragnaros.git
 
@@ -40,7 +40,7 @@ dependencies:
   git: git@bitbucket.org:qamine/codacy-activities.git
 
 - name: remote-provider-service
-  version: 2.44.0
+  version: 2.45.1
   repository: https://charts.codacy.com/stable
   git: git@bitbucket.org:qamine/remote-provider-service.git
 
@@ -65,17 +65,17 @@ dependencies:
   git: git@bitbucket.org:qamine/codacy-core.git
 
 - name: engine
-  version: 6.0.0
+  version: 6.1.1
   repository: https://charts.codacy.com/stable
   git: git@bitbucket.org:qamine/codacy-worker.git
 
 - name: codacy-api
-  version: 5.3.1
+  version: 5.8.0
   repository: https://charts.codacy.com/stable
   git: git@bitbucket.org:qamine/codacy-website.git
 
 - name: worker-manager
-  version: 9.0.1
+  version: 9.0.2
   repository: https://charts.codacy.com/stable
   git: git@bitbucket.org:qamine/worker-manager.git
 


### PR DESCRIPTION
This PR will allow us to push to the "hourly" namespace whenever a merge to master happens.
This PR will also bump the component versions for today's release.

The 'hourly' name is now quite misleading and we should revisit this asap (after the release).