### PR TITLE
fix: Add missing config for engine api

### DIFF
--- a/codacy/values.yaml
+++ b/codacy/values.yaml
@@ -10,6 +10,8 @@ global:
       url: "codacy-hotspots-api"
     engine:
       url: "codacy-engine"
+    engineApi:
+      url: "codacy-engine"
     listener:
       url: "codacy-listener"
     activities:


### PR DESCRIPTION
Because of this PR(https://bitbucket.org/qamine/codacy-website/pull-requests/2796/feature-use-engines-new-api/diff) on codacy-worker we now have a new value with the url for the engineApi.