### PR TITLE
refactor: remove duplicated lints

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,15 +108,9 @@ references:
     attach_workspace:
           at: ~/
 
-  helm_lint: &helm_lint
-    run:
-          name: "Helm lint"
-          command: helm lint codacy/
-
   deploy_to_cluster: &deploy_to_cluster
     steps:
       - <<: *attach_workspace
-      - <<: *helm_lint
       - <<: *doctl_authenticate
       - deploy:
           name: Install Codacy
@@ -125,7 +119,6 @@ references:
   deploy_to_cluster_from_chartmuseum: &deploy_to_cluster_from_chartmuseum
     steps:
       - <<: *attach_workspace
-      - <<: *helm_lint
       - <<: *doctl_authenticate
       - deploy:
           name: Install Codacy
@@ -134,7 +127,6 @@ references:
   rotate_pods: &rotate_pods
     steps:
       - <<: *attach_workspace
-      - <<: *helm_lint
       - <<: *doctl_authenticate
       - deploy:
           name: Rotate Pods

--- a/.doks/Makefile
+++ b/.doks/Makefile
@@ -53,7 +53,7 @@ rotate_pods: set_cluster_context
 
 .PHONY: set_cluster_context
 set_cluster_context:
-	echo '1' | doctl kubernetes cluster kubeconfig save ${DOKS_CLUSTER_NAME} --set-current-context
+	doctl kubernetes cluster kubeconfig save ${DOKS_CLUSTER_NAME} --set-current-context
 
 .PHONY: remove_codacy
 remove_codacy: set_cluster_context


### PR DESCRIPTION
All workflows have a job to lint the chart so there is no point in linting the chart again on other jobs.