### PR TITLE
refactor: deprecate rotate pods with atomic + recreate pods

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,15 +131,6 @@ references:
           name: Install Codacy
           command: make -C .doks/ deploy_to_doks_from_chartmuseum RELEASE=$RELEASE NAMESPACE=$NAMESPACE VERSION=$(cat .version) HELM_REPOSITORY=$HELM_REPOSITORY
 
-  rotate_pods: &rotate_pods
-    steps:
-      - <<: *attach_workspace
-      - <<: *helm_lint
-      - <<: *doctl_authenticate
-      - deploy:
-          name: Rotate Pods
-          command: make -C .doks/ rotate_pods NAMESPACE=$NAMESPACE
-
   validate_deployment_status_on_cluster: &validate_deployment_status_on_cluster
     steps:
       - <<: *attach_workspace
@@ -230,30 +221,6 @@ jobs:
     environment:
       <<: *nightly_environment_1_15
     <<: *deploy_to_cluster_from_chartmuseum
-
-  rotate_pods_hourly:
-    <<: *default_doks_image
-    environment:
-      <<: *qa_environment_hourly
-    <<: *rotate_pods
-
-  rotate_pods_nightly_1_14:
-    <<: *default_doks_image
-    environment:
-      <<: *nightly_environment_1_14
-    <<: *rotate_pods
-
-  rotate_pods_nightly_1_15:
-    <<: *default_doks_image
-    environment:
-      <<: *nightly_environment_1_15
-    <<: *rotate_pods
-
-  rotate_pods_release:
-    <<: *default_doks_image
-    environment:
-      <<: *release_environment
-    <<: *rotate_pods
 
   validate_deployment_status_hourly:
     <<: *default_doks_image
@@ -680,17 +647,10 @@ workflows:
           filters:
             tags:
               only: /^release-.*/
-      - rotate_pods_release:
-          context: CodacyDO
-          requires:
-            - deploy_to_doks_release
-          filters:
-            tags:
-              only: /^release-.*/
       - validate_deployment_status_release:
           context: CodacyDO
           requires:
-            - rotate_pods_release
+            - deploy_to_doks_release
           filters:
             tags:
               only: /^release-.*/

--- a/.doks/Makefile
+++ b/.doks/Makefile
@@ -8,6 +8,7 @@ DEPLOYMENTS=$(shell kubectl get deployments -n "${NAMESPACE}" | awk '{print $$1}
 deploy_to_doks: set_cluster_context
 	$(MAKE) -C ../ update_dependencies
 	helm upgrade --install ${RELEASE_NAME} ../codacy/ \
+		--atomic \
 		--recreate-pods \
 		-f values.yaml \
 		--namespace ${NAMESPACE} \
@@ -27,6 +28,7 @@ deploy_to_doks_from_chartmuseum: set_cluster_context
 	$(MAKE) -C ../ setup_helm_repos
 	helm repo update
 	helm upgrade --install ${RELEASE_NAME} ${HELM_REPOSITORY}/codacy \
+		--atomic \
 		--recreate-pods \
 		-f values.yaml \
 		--version ${VERSION} \
@@ -41,15 +43,6 @@ deploy_to_doks_from_chartmuseum: set_cluster_context
 		--set global.codacy.backendUrl=${CODACY_URL} \
 		--set listener.nfsserverprovisioner.storageClass.name="${RELEASE_NAME}-listener-cache-class" \
 		--set global.features.cloneSubmodules=true
-
-define rotate_pod
-kubectl patch deployment $(strip $(1)) -n ${NAMESPACE} -p '{"spec":{"template":{"metadata":{"annotations":{"date": "'$(shell date +'%Y-%m-%dT%H:%M:%S')'" }}}}}';
-kubectl rollout status "deployment/$(strip $(1))" -n ${NAMESPACE} --watch --timeout=30m;
-endef
-
-.PHONY: rotate_pods
-rotate_pods: set_cluster_context
-	$(foreach DEPLOYMENT, $(DEPLOYMENTS),$(call rotate_pod, $(DEPLOYMENT)))
 
 .PHONY: set_cluster_context
 set_cluster_context:


### PR DESCRIPTION
we no longer need this.
by using --atomic we ensure that we only move forward with successful upgrades. If they fail, the cluster should be left in the previous successful helm upgrade.