### PR TITLE
fix: fluentd capture only the release namespace

### DIFF
--- a/codacy/values.yaml
+++ b/codacy/values.yaml
@@ -327,6 +327,7 @@ fluentdoperator:
   expirationDays: 14
   rbac:
     create: true
+  useReleaseNamespaceOnly: true
 
 ## YOU ARE NOT ADVISED TO CHANGE BEYOND THIS POINT
 ## Defaults for Internal Storage coming from requirements


### PR DESCRIPTION
The fluentd operator was aggregating logs from all namespaces by default.
Since we have 3 installations of codacy in 3 different namespaces in the same cluster, this means that each fluentd operator would aggregate logs from the 3 different installations, which is not what we would like.

Following [this PR](https://github.com/codacy/kube-fluentd-operator/pull/5), we can set the value to only use the release namespace.
