### PR TITLE
fix: fixing mkdocs material

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -395,6 +395,20 @@ jobs:
           message: $(cat changelogs/changelog.txt)
 
 workflows:
+
+  fix_docs:
+    jobs:
+      - codacy/checkout_and_version:
+          dev_branch: "master"
+          release_branch: "release"
+          filters:
+            branches:
+              only:
+                - fix-mkdocs
+      - upload_docs:
+          requires:
+            - codacy/checkout_and_version
+
   helm_lint:
     jobs:
       - codacy/checkout_and_version:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -395,20 +395,6 @@ jobs:
           message: $(cat changelogs/changelog.txt)
 
 workflows:
-
-  fix_docs:
-    jobs:
-      - codacy/checkout_and_version:
-          dev_branch: "master"
-          release_branch: "release"
-          filters:
-            branches:
-              only:
-                - fix-mkdocs
-      - upload_docs:
-          requires:
-            - codacy/checkout_and_version
-
   helm_lint:
     jobs:
       - codacy/checkout_and_version:

--- a/requirements.pip
+++ b/requirements.pip
@@ -1,2 +1,2 @@
 mkdocs==1.0.4
-mkdocs-material==4.6.0
+mkdocs-material==4.6.2


### PR DESCRIPTION
upload_docs started failing with:
`ERROR: mkdocs-material 4.6.0 has requirement markdown<3.2, but you'll have markdown 3.2 which is incompatible.`
https://circleci.com/gh/codacy/chart/7439

I have bumped the mk-docs patch version which seems to have fixed the issue on this branch.