### PR TITLE
fix: default to all deployments on rotate pods

### DIFF
--- a/.doks/Makefile
+++ b/.doks/Makefile
@@ -2,7 +2,7 @@ CODACY_URL?="http://k8s.dev.codacy.org"
 RELEASE_NAME?="codacy"
 NAMESPACE?="codacy"
 HELM_REPOSITORY?=codacy-incubator
-DEPLOYMENTS=$(shell kubectl get deployments -n "${NAMESPACE}" | awk '{print $$1}' | tail -n +2 | grep -v minio)
+DEPLOYMENTS?=$(shell kubectl get deployments -n "${NAMESPACE}" | awk '{print $$1}' | tail -n +2 | grep -v minio)
 
 .PHONY: deploy_to_doks
 deploy_to_doks: set_cluster_context


### PR DESCRIPTION
With this PR, we can tell a specific component to only rotate its deployment when deploying to dev SH, instead of rotation all deployments.