### PR TITLE
refactor: expose worker version patching on makefile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,9 @@ references:
           MAVEN_OPTS: -showversion -Xms256m -Xmx512m
     working_directory: ~/workdir
 
-  # doks node types can be found here https://developers.digitalocean.com/documentation/v2/
+  ##################################################################################
+  #  Environment variables that differentiate for each environment/installation
+  ##################################################################################
   dev_environment: &dev_environment
     DOKS_CLUSTER_NAME: codacy-doks-cluster-dev
     DO_TF_WORKSPACE: dev
@@ -61,6 +63,9 @@ references:
     HELM_REPOSITORY: codacy-incubator
     CODACY_URL: http://release.k8s.dev.codacy.org
 
+  ###################################################
+  #  Env variables identify each deployment channel
+  ##################################################
   unstable_helm_channel: &unstable_helm_channel
     CHANNEL: unstable
     HELM_REPOSITORY: codacy-unstable
@@ -77,6 +82,9 @@ references:
     CHANNEL: stable
     HELM_REPOSITORY: codacy-stable
 
+  #########################################
+  #  Anchors for steps
+  #########################################
   doctl_authenticate: &doctl_authenticate
     run:
       name: "Setup DO Credentials"
@@ -92,7 +100,7 @@ references:
     attach_workspace:
           at: ~/
 
-  deploy_to_cluster: &deploy_to_cluster
+  deploy_to_doks_from_local_dir: &deploy_to_doks_from_local_dir
     steps:
       - <<: *attach_workspace
       - <<: *doctl_authenticate
@@ -157,12 +165,16 @@ references:
           steps:
             - <<: *persist_to_workspace
 
+############
+#  JOBS
+############
+
 jobs:
-  deploy_to_doks:
+  deploy_to_doks_dev:
     <<: *default_doks_image
     environment:
       <<: *dev_environment
-    <<: *deploy_to_cluster
+    <<: *deploy_to_doks_from_local_dir
 
   deploy_to_doks_nightly_1_14:
     <<: *default_doks_image
@@ -332,6 +344,10 @@ jobs:
           title: $(cat .version)
           message: $(cat changelogs/changelog.txt)
 
+############
+#  WORKFLOWS
+############
+
 workflows:
   helm_lint:
     jobs:
@@ -347,7 +363,7 @@ workflows:
           requires:
             - codacy/checkout_and_version
 
-  deploy_chart_to_cluster:
+  deploy_chart_to_dev_cluster:
     jobs:
       - codacy/checkout_and_version:
           dev_branch: "master"
@@ -361,17 +377,17 @@ workflows:
           cmd: helm lint --set-string global.akka.sessionSecret="" codacy/
           requires:
             - codacy/checkout_and_version
-      - helm_push_unstable:
-          context: CodacyDO
-          requires:
-            - deploy_to_doks
-      - deploy_to_doks:
+      - deploy_to_doks_dev:
           context: CodacyDO
           requires:
             - helm_lint
+      - helm_push_unstable:
+          context: CodacyDO
+          requires:
+            - deploy_to_doks_dev
       - upload_docs:
           requires:
-            - deploy_to_doks
+            - deploy_to_doks_dev
 
   nightly_pipeline:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,12 +29,13 @@ references:
     K8S_VERSION: 1.14
     NUM_NODES: 5
     HELM_REPOSITORY: codacy-unstable
+    CODACY_URL: http://dev.k8s.dev.codacy.org
 
   nightly_base_environment: &nightly_base_environment
     RELEASE_NAME: codacy-nightly
     NAMESPACE: codacy-nightly
     NODE_TYPE: s-20vcpu-96gb
-    NUM_NODES: 4
+    NUM_NODES: 5
     HELM_REPOSITORY: codacy-unstable
 
   nightly_environment_1_14: &nightly_environment_1_14
@@ -51,31 +52,14 @@ references:
 
   release_environment: &release_environment
     DOKS_CLUSTER_NAME: codacy-doks-cluster-release
-    DO_TF_WORKSPACE: release
+    DO_TF_WORKSPACE: dev
     RELEASE_NAME: codacy-release
     NAMESPACE: codacy-release
     NODE_TYPE: s-20vcpu-96gb
     K8S_VERSION: 1.15
-    NUM_NODES: 4
-    CODACY_URL: http://release.dev.codacy.org
-    HELM_REPOSITORY: codacy-incubator
-
-  qa_environment_hourly: &qa_environment_hourly
-    SELENIUM_DRIVER_URL: http://localhost:4444/wd/hub
-    HUB_URL: http://localhost:4444/wd/hub
-    PROJECT_NAME: codacy-chart
-    LAUNCH_DESCRIPTION: 'Automated Tests Ran by CircleCI'
-    LAUNCH_TAG: CIRCLECI;WEB;DIGITALOCEAN;ENTERPRISE
-    RP_ENDPOINT: https://reportportal.staging.codacy.org
-    DOKS_CLUSTER_NAME: codacy-doks-cluster-dev
-    DO_TF_WORKSPACE: hourly
-    RELEASE_NAME: codacy-hourly
-    NAMESPACE: codacy-hourly
-    NODE_TYPE: s-20vcpu-96gb
-    K8S_VERSION: 1.14
     NUM_NODES: 5
-    HELM_REPOSITORY: codacy-unstable
-    CODACY_URL: http://k8s.hourly.dev.codacy.org
+    HELM_REPOSITORY: codacy-incubator
+    CODACY_URL: http://release.k8s.dev.codacy.org
 
   unstable_helm_channel: &unstable_helm_channel
     CHANNEL: unstable
@@ -114,7 +98,7 @@ references:
       - <<: *doctl_authenticate
       - deploy:
           name: Install Codacy
-          command: make -C .doks/ deploy_to_doks RELEASE=$RELEASE NAMESPACE=$NAMESPACE
+          command: make -C .doks/ deploy_to_doks RELEASE_NAME=$RELEASE_NAME NAMESPACE=$NAMESPACE
 
   deploy_to_cluster_from_chartmuseum: &deploy_to_cluster_from_chartmuseum
     steps:
@@ -122,7 +106,7 @@ references:
       - <<: *doctl_authenticate
       - deploy:
           name: Install Codacy
-          command: make -C .doks/ deploy_to_doks_from_chartmuseum RELEASE=$RELEASE NAMESPACE=$NAMESPACE VERSION=$(cat .version) HELM_REPOSITORY=$HELM_REPOSITORY
+          command: make -C .doks/ deploy_to_doks_from_chartmuseum RELEASE_NAME=$RELEASE_NAME NAMESPACE=$NAMESPACE VERSION=$(cat .version) HELM_REPOSITORY=$HELM_REPOSITORY
 
   helm_push: &helm_push
     steps:
@@ -180,12 +164,6 @@ jobs:
       <<: *dev_environment
     <<: *deploy_to_cluster
 
-  deploy_to_doks_hourly:
-    <<: *default_doks_image
-    environment:
-      <<: *qa_environment_hourly
-    <<: *deploy_to_cluster_from_chartmuseum
-
   deploy_to_doks_nightly_1_14:
     <<: *default_doks_image
     environment:
@@ -235,43 +213,6 @@ jobs:
         type: boolean
         default: false
     <<: *update_codacy_url
-
-  update_codacy_url_hourly:
-    <<: *default_doks_image
-    environment:
-      <<: *qa_environment_hourly
-    parameters:
-      persist_codacy_url:
-        type: boolean
-        default: true
-    <<: *update_codacy_url
-
-  test_api_dev:
-    <<: *qa_automation_image
-    environment:
-      <<: *dev_environment
-      <<: *qa_environment_hourly
-      TEST_PATH: Suite/Enterprise/K8S_HOURLY/API_DEV.xml
-      LAUNCH_NAME: ENTERPRISE_API_HOURLY_TESTS
-    <<: *qa_job
-
-  test_e2e_dev:
-    <<: *qa_automation_image
-    environment:
-      <<: *dev_environment
-      <<: *qa_environment_hourly
-      TEST_PATH: Suite/Enterprise/K8S_HOURLY/E2E_DEV.xml
-      LAUNCH_NAME: ENTERPRISE_E2E_HOURLY_TESTS
-    <<: *qa_job
-
-  test_web_dev:
-    <<: *qa_automation_image
-    environment:
-      <<: *dev_environment
-      <<: *qa_environment_hourly
-      TEST_PATH: Suite/Enterprise/K8S_HOURLY/WEB_DEV.xml
-      LAUNCH_NAME: ENTERPRISE_WEB_HOURLY_TESTS
-    <<: *qa_job
 
   set_chart_version_nightly:
     <<: *default_doks_image
@@ -431,49 +372,6 @@ workflows:
       - upload_docs:
           requires:
             - deploy_to_doks
-
-  hourly_pipeline:
-    jobs:
-      - codacy/checkout_and_version:
-          dev_branch: "master"
-          release_branch: "release"
-          filters:
-              branches:
-                only:
-                  - feature/hourly-tests
-      - codacy/helm_aws:
-          name: helm_lint
-          cmd: helm lint --set-string global.akka.sessionSecret="" codacy/
-          requires:
-            - codacy/checkout_and_version
-      - update_versions:
-          context: CodacyDO
-          requires:
-            - helm_lint
-      - helm_push_unstable:
-          context: CodacyDO
-          requires:
-            - update_versions
-      - get_changelogs:
-          context: CodacyDO
-          requires:
-            - update_versions
-      - deploy_to_doks_hourly:
-          context: CodacyDO
-          requires:
-            - helm_push_unstable
-      - test_api_dev:
-          context: CodacyDO
-          requires:
-            - deploy_to_doks_hourly
-      - test_e2e_dev:
-          context: CodacyDO
-          requires:
-            - deploy_to_doks_hourly
-      - test_web_dev:
-          context: CodacyDO
-          requires:
-            - deploy_to_doks_hourly
 
   nightly_pipeline:
     triggers:

--- a/.doks/Makefile
+++ b/.doks/Makefile
@@ -3,6 +3,7 @@ RELEASE_NAME?="codacy"
 NAMESPACE?="codacy"
 HELM_REPOSITORY?=codacy-incubator
 DEPLOYMENTS?=$(shell kubectl get deployments -n "${NAMESPACE}" | awk '{print $$1}' | tail -n +2 | grep -v minio)
+WORKER_VERSION?=$(shell grep "engine" -A 2 codacy/requirements.lock | grep version | cut -d : -f 2 | tr -d '[:blank:]')
 
 define call_helm_install
 	helm upgrade --install ${1} ${3} \
@@ -20,16 +21,17 @@ define call_helm_install
 	--set global.codacy.url=${4} \
 	--set global.codacy.backendUrl=${4} \
 	--set listener.nfsserverprovisioner.storageClass.name="${1}-listener-cache-class" \
-	--set global.features.cloneSubmodules=true \
 	--set global.bitbucketenterprise.consumerPublicKey=$${BITBUCKET_ENTERPRISE_PUBLIC_KEY} \
 	--set global.bitbucketenterprise.consumerPrivateKey=$${BITBUCKET_ENTERPRISE_PRIVATE_KEY}
+	--set worker-manager.config.codacy.worker.image=${5} \
+	--set global.features.cloneSubmodules=true
 
   $(foreach DEPLOYMENT, $(DEPLOYMENTS),$(call rotate_pod, $(DEPLOYMENT)))
 endef
 
 .PHONY: deploy_to_doks_atomic
 deploy_to_doks_atomic:
-	$(call call_helm_install,${RELEASE_NAME},${NAMESPACE},../codacy/,${CODACY_URL})
+	$(call call_helm_install,${RELEASE_NAME},${NAMESPACE},../codacy/,${CODACY_URL},${WORKER_VERSION})
 
 .PHONY: deploy_to_doks_from_local_dir
 deploy_to_doks_from_local_dir: set_cluster_context
@@ -40,7 +42,7 @@ deploy_to_doks_from_local_dir: set_cluster_context
 deploy_to_doks_from_chartmuseum: set_cluster_context
 	$(MAKE) -C ../ setup_helm_repos
 	helm repo update
-	$(call call_helm_install,${RELEASE_NAME},${NAMESPACE},${HELM_REPOSITORY}/codacy --version ${VERSION},${CODACY_URL})
+	$(call call_helm_install,${RELEASE_NAME},${NAMESPACE},${HELM_REPOSITORY}/codacy --version ${VERSION},${CODACY_URL},${WORKER_VERSION})
 
 define rotate_pod
   kubectl patch deployment $(strip $(1)) -n ${NAMESPACE} -p '{"spec":{"template":{"metadata":{"annotations":{"date": "'$(shell date +'%Y-%m-%dT%H:%M:%S')'" }}}}}';

--- a/.doks/Makefile
+++ b/.doks/Makefile
@@ -27,13 +27,13 @@ define call_helm_install
   $(foreach DEPLOYMENT, $(DEPLOYMENTS),$(call rotate_pod, $(DEPLOYMENT)))
 endef
 
-.PHONY: deploy_to_doks
-deploy_to_doks: set_cluster_context
-	$(MAKE) -C ../ update_dependencies
-	$(call call_helm_install,${RELEASE_NAME},${NAMESPACE},../codacy/,${CODACY_URL})
-
 .PHONY: deploy_to_doks_atomic
 deploy_to_doks_atomic:
+	$(call call_helm_install,${RELEASE_NAME},${NAMESPACE},../codacy/,${CODACY_URL})
+
+.PHONY: deploy_to_doks_from_local_dir
+deploy_to_doks_from_local_dir: set_cluster_context
+	$(MAKE) -C ../ update_dependencies
 	$(call call_helm_install,${RELEASE_NAME},${NAMESPACE},../codacy/,${CODACY_URL})
 
 .PHONY: deploy_to_doks_from_chartmuseum

--- a/.doks/Makefile
+++ b/.doks/Makefile
@@ -20,7 +20,9 @@ define call_helm_install
 	--set global.codacy.url=${4} \
 	--set global.codacy.backendUrl=${4} \
 	--set listener.nfsserverprovisioner.storageClass.name="${1}-listener-cache-class" \
-	--set global.features.cloneSubmodules=true
+	--set global.features.cloneSubmodules=true \
+	--set global.bitbucketenterprise.consumerPublicKey=$${BITBUCKET_ENTERPRISE_PUBLIC_KEY} \
+	--set global.bitbucketenterprise.consumerPrivateKey=$${BITBUCKET_ENTERPRISE_PRIVATE_KEY}
 
   $(foreach DEPLOYMENT, $(DEPLOYMENTS),$(call rotate_pod, $(DEPLOYMENT)))
 endef

--- a/.doks/Makefile
+++ b/.doks/Makefile
@@ -3,7 +3,7 @@ RELEASE_NAME?="codacy"
 NAMESPACE?="codacy"
 HELM_REPOSITORY?=codacy-incubator
 DEPLOYMENTS?=$(shell kubectl get deployments -n "${NAMESPACE}" | awk '{print $$1}' | tail -n +2 | grep -v minio)
-WORKER_VERSION?=$(shell grep "engine" -A 2 codacy/requirements.lock | grep version | cut -d : -f 2 | tr -d '[:blank:]')
+WORKER_VERSION?=$(shell grep "engine" -A 2 ../codacy/requirements.lock | grep version | cut -d : -f 2 | tr -d '[:blank:]')
 
 define rotate_pod
   kubectl patch deployment $(strip $(1)) -n ${NAMESPACE} -p '{"spec":{"template":{"metadata":{"annotations":{"date": "'$(shell date +'%Y-%m-%dT%H:%M:%S')'" }}}}}';

--- a/.doks/Makefile
+++ b/.doks/Makefile
@@ -5,6 +5,11 @@ HELM_REPOSITORY?=codacy-incubator
 DEPLOYMENTS?=$(shell kubectl get deployments -n "${NAMESPACE}" | awk '{print $$1}' | tail -n +2 | grep -v minio)
 WORKER_VERSION?=$(shell grep "engine" -A 2 codacy/requirements.lock | grep version | cut -d : -f 2 | tr -d '[:blank:]')
 
+define rotate_pod
+  kubectl patch deployment $(strip $(1)) -n ${NAMESPACE} -p '{"spec":{"template":{"metadata":{"annotations":{"date": "'$(shell date +'%Y-%m-%dT%H:%M:%S')'" }}}}}';
+  kubectl rollout status "deployment/$(strip $(1))" -n ${NAMESPACE} --watch --timeout=30m;
+endef
+
 define call_helm_install
 	helm upgrade --install ${1} ${3} \
 	--atomic \
@@ -29,25 +34,31 @@ define call_helm_install
   $(foreach DEPLOYMENT, $(DEPLOYMENTS),$(call rotate_pod, $(DEPLOYMENT)))
 endef
 
-.PHONY: deploy_to_doks_atomic
-deploy_to_doks_atomic:
+.PHONY: helm_install_from_local_dir
+helm_install_from_local_dir:
 	$(call call_helm_install,${RELEASE_NAME},${NAMESPACE},../codacy/,${CODACY_URL},${WORKER_VERSION})
 
-.PHONY: deploy_to_doks_from_local_dir
-deploy_to_doks_from_local_dir: set_cluster_context
-	$(MAKE) -C ../ update_dependencies
-	$(call call_helm_install,${RELEASE_NAME},${NAMESPACE},../codacy/,${CODACY_URL})
-
-.PHONY: deploy_to_doks_from_chartmuseum
-deploy_to_doks_from_chartmuseum: set_cluster_context
-	$(MAKE) -C ../ setup_helm_repos
-	helm repo update
+.PHONY: helm_install_from_chartmuseum
+helm_install_from_local_dir:
 	$(call call_helm_install,${RELEASE_NAME},${NAMESPACE},${HELM_REPOSITORY}/codacy --version ${VERSION},${CODACY_URL},${WORKER_VERSION})
 
-define rotate_pod
-  kubectl patch deployment $(strip $(1)) -n ${NAMESPACE} -p '{"spec":{"template":{"metadata":{"annotations":{"date": "'$(shell date +'%Y-%m-%dT%H:%M:%S')'" }}}}}';
-  kubectl rollout status "deployment/$(strip $(1))" -n ${NAMESPACE} --watch --timeout=30m;
-endef
+.PHONY: helm_repo_update
+helm_repo_update:
+	helm repo update
+
+.PHONY: setup_helm_repos
+setup_helm_repos:
+	$(MAKE) -C ../ setup_helm_repos
+
+.PHONY: update_dependencies
+update_dependencies:
+	$(MAKE) -C ../ update_dependencies
+
+.PHONY: deploy_to_doks_from_local_dir
+deploy_to_doks_from_local_dir: set_cluster_context update_dependencies helm_install_from_local_dir
+
+.PHONY: deploy_to_doks_from_chartmuseum
+deploy_to_doks_from_chartmuseum: set_cluster_context setup_helm_repos helm_repo_update helm_install_from_chartmuseum
 
 .PHONY: set_cluster_context
 set_cluster_context:

--- a/.doks/Makefile
+++ b/.doks/Makefile
@@ -1,4 +1,4 @@
-CODACY_URL?="http://k8s.dev.codacy.org"
+CODACY_URL?="http://dev.k8s.dev.codacy.org"
 RELEASE_NAME?="codacy"
 NAMESPACE?="codacy"
 HELM_REPOSITORY?=codacy-incubator

--- a/.doks/values.yaml
+++ b/.doks/values.yaml
@@ -91,3 +91,6 @@ global:
     hostname: "bitbucket-server.codacy.org"
     protocol: "http"
     port: 7990
+    consumerKey: "codacy-stash-link"
+    consumerPublicKey: "CHANGE_ME"
+    consumerPrivateKey: "CHANGE_ME"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-ENGINE_VERSION:=$(shell grep "engine" -A 2 codacy/requirements.lock | grep version | cut -d : -f 2 | tr -d '[:blank:]')
+ENGINE_VERSION?=$(shell grep "engine" -A 2 codacy/requirements.lock | grep version | cut -d : -f 2 | tr -d '[:blank:]')
+
 .PHONY: setup_helm_repos
 setup_helm_repos:
 	helm repo add codacy-stable https://charts.codacy.com/stable
@@ -6,7 +7,6 @@ setup_helm_repos:
 	helm repo add codacy-incubator https://charts.codacy.com/incubator
 	helm repo add codacy-external https://charts.codacy.com/external
 
-.PHONY: update_worker_version
 update_worker_version:
 	@echo ${ENGINE_VERSION}
 	ytool -f "./codacy/values.yaml" -s worker-manager.config.codacy.worker.image "${ENGINE_VERSION}" -e

--- a/README.md
+++ b/README.md
@@ -215,11 +215,12 @@ in this repo.
 Currently, we have these set of installations done through `circleci`.
 All of them serve different purposes.
 
-| Installation | Cluster                     | Cluster        | Purpose                                                                                                                 | Url                                |
-| ------------ | --------------------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
-| Dev          | codacy-doks-cluster-dev     | codacy         | Updated automatically on each component pipeline. Rolling release of [unstable](https://charts.codacy.com/unstable/api) | <http://k8s.dev.codacy.org>        |
-| Hourly       | codacy-doks-cluster-dev     | codacy-hourly  | Used for development. Manually updated                                                                                  | <http://k8s.hourly.dev.codacy.org> |
-| Release      | codacy-doks-cluster-release | codacy-release | Used for releases. Updated when the process on the [RELEASE.md](./RELEASE.md) is triggered.                             | <http://release.dev.codacy.org>    |
+| Installation | Cluster                     | Namespace         | Purpose                                                                                                                 | Url                                    |
+| ------------ | --------------------------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| Dev          | codacy-doks-cluster-dev     | codacy            | Updated automatically on each component pipeline. Rolling release of [unstable](https://charts.codacy.com/unstable/api) | <http://dev.k8s.dev.codacy.org>        |
+| Hourly       | codacy-doks-cluster-dev     | codacy-hourly     | Used for development. Manually updated                                                                                  | <http://hourly.k8s.dev.codacy.org>     |
+| Release      | codacy-doks-cluster-dev     | codacy-release    | Used for releases. Updated when the process on the [RELEASE.md](./RELEASE.md) is triggered.                             | <http://release.k8s.dev.codacy.org>    |
+| Production   | codacy-doks-cluster-dev     | codacy-production | Used after releases to deploy the produced chart. Represents the latest release available to clients.                   | <http://production.k8s.dev.codacy.org> |
 
 ### Set up your environment for DigitalOcean clusters
 

--- a/README.md
+++ b/README.md
@@ -56,65 +56,67 @@ The following table lists the configurable parameters of the Codacy chart and th
 
 Global parameters apply to all sub-charts and make it easier to configure resources across different components.
 
-| Parameter                               | Description                                                                                                  | Default         |
-| --------------------------------------- | ------------------------------------------------------------------------------------------------------------ | --------------- |
-| `global.codacy.url`                     | Hostname to your Codacy installation                                                                         | `nil`           |
-| `global.codacy.backendUrl`              | Hostname to your Codacy installation                                                                         | `nil`           |
-| `global.play.cryptoSecret`              | Secrets used internally for encryption. Generate one with \`openssl rand -base64 128 \| tr -dc 'a-zA-Z0-9'\` | `nil`           |
-| `global.akka.sessionSecret`             | Secrets used internally for encryption. Generate one with \`openssl rand -base64 128 \| tr -dc 'a-zA-Z0-9'\` | `nil`           |
-| `global.filestore.contentsSecret`       | Secrets used internally for encryption. Generate one with \`openssl rand -base64 128 \| tr -dc 'a-zA-Z0-9'\` | `nil`           |
-| `global.filestore.uuidSecret`           | Secrets used internally for encryption. Generate one with \`openssl rand -base64 128 \| tr -dc 'a-zA-Z0-9'\` | `nil`           |
-| `global.cacheSecret`                    | Secrets used internally for encryption. Generate one with \`openssl rand -base64 128 \| tr -dc 'a-zA-Z0-9'\` | `nil`           |
-| `global.minio.create`                   | Create minio internally                                                                                      | `nil`           |
-| `global.rabbitmq.create`                | Create rabbitmq internally                                                                                   | `nil`           |
-| `global.rabbitmq.rabbitmqUsername`      | Username for rabbitmq. If you are using the bundled version, change the `rabbitmq-ha.rabbitmqUsername` also. | `nil`           |
-| `global.rabbitmq.rabbitmqPassword`      | Password for rabbitmq. If you are using the bundled version, change the `rabbitmq-ha.rabbitmqPassword` also. | `nil`           |
-| `global.defaultdb.postgresqlUsername`   | Username of the Postgresql server                                                                            | `codacy`        |
-| `global.defaultdb.postgresqlDatabase`   | Database name of the Postgresql server                                                                       | `default`       |
-| `global.defaultdb.postgresqlPassword`   | Hostname of the Postgresql server                                                                            | `nil`           |
-| `global.defaultdb.host`                 | Hostname of the Postgresql server                                                                            | `nil`           |
-| `global.defaultdb.service.port`         | Port of the Postgresql server                                                                                | `5432`          |
-| `global.analysisdb.postgresqlUsername`  | Username of the Postgresql server                                                                            | `codacy`        |
-| `global.analysisdb.postgresqlDatabase`  | Database name of the Postgresql server                                                                       | `analysis`      |
-| `global.analysisdb.postgresqlPassword`  | Hostname of the Postgresql server                                                                            | `nil`           |
-| `global.analysisdb.host`                | Hostname of the Postgresql server                                                                            | `nil`           |
-| `global.analysisdb.service.port`        | Port of the Postgresql server                                                                                | `5432`          |
-| `global.resultsdb.postgresqlUsername`   | Username of the Postgresql server                                                                            | `codacy`        |
-| `global.resultsdb.postgresqlDatabase`   | Database name of the Postgresql server                                                                       | `results201709` |
-| `global.resultsdb.postgresqlPassword`   | Hostname of the Postgresql server                                                                            | `nil`           |
-| `global.resultsdb.host`                 | Hostname of the Postgresql server                                                                            | `nil`           |
-| `global.resultsdb.service.port`         | Port of the Postgresql server                                                                                | `5432`          |
-| `global.metricsdb.postgresqlUsername`   | Username of the Postgresql server                                                                            | `codacy`        |
-| `global.metricsdb.postgresqlDatabase`   | Database name of the Postgresql server                                                                       | `metrics`       |
-| `global.metricsdb.postgresqlPassword`   | Hostname of the Postgresql server                                                                            | `nil`           |
-| `global.metricsdb.host`                 | Hostname of the Postgresql server                                                                            | `nil`           |
-| `global.metricsdb.service.port`         | Port of the Postgresql server                                                                                | `5432`          |
-| `global.filestoredb.postgresqlUsername` | Username of the Postgresql server                                                                            | `codacy`        |
-| `global.filestoredb.postgresqlDatabase` | Database name of the Postgresql server                                                                       | `filestore`     |
-| `global.filestoredb.postgresqlPassword` | Hostname of the Postgresql server                                                                            | `nil`           |
-| `global.filestoredb.host`               | Hostname of the Postgresql server                                                                            | `nil`           |
-| `global.filestoredb.service.port`       | Port of the Postgresql server                                                                                | `5432`          |
-| `global.jobsdb.postgresqlUsername`      | Username of the Postgresql server                                                                            | `codacy`        |
-| `global.jobsdb.postgresqlDatabase`      | Database name of the Postgresql server                                                                       | `jobs`          |
-| `global.jobsdb.postgresqlPassword`      | Hostname of the Postgresql server                                                                            | `nil`           |
-| `global.jobsdb.host`                    | Hostname of the Postgresql server                                                                            | `nil`           |
-| `global.jobsdb.service.port`            | Port of the Postgresql server                                                                                | `5432`          |
-| `global.githubEnterprise.enabled`       | Enable githubEnterprise                                                                                      | `nil`           |
-| `global.githubEnterprise.hostname`      | Hostname of githubEnterprise instance                                                                        | `nil`           |
-| `global.githubEnterprise.protocol`      | Protocol of githubEnterprise instance                                                                        | `nil`           |
-| `global.githubEnterprise.port`          | Port of githubEnterprise instance                                                                            | `nil`           |
-| `global.githubEnterprise.isPrivateMode` | Status of private mode on githubEnterprise instance                                                          | `nil`           |
-| `global.githubEnterprise.disableSSL`    | Disable certificate validation on interaction with githubEnterprise instance                                 | `nil`           |
-| `global.gitlabEnterprise.enabled`       | Enable gitlabEnterprise                                                                                      | `nil`           |
-| `global.gitlabEnterprise.hostname`      | Hostname of gitlabEnterprise instance                                                                        | `nil`           |
-| `global.gitlabEnterprise.protocol`      | Protocol of gitlabEnterprise instance                                                                        | `nil`           |
-| `global.gitlabEnterprise.port`          | Port of gitlabEnterprise instance                                                                            | `nil`           |
-| `global.bitbucketEnterprise.enabled`    | Enable bitbucketEnterprise                                                                                   | `nil`           |
-| `global.bitbucketEnterprise.hostname`   | Hostname of bitbucketEnterprise instance                                                                     | `nil`           |
-| `global.bitbucketEnterprise.protocol`   | Protocol of bitbucketEnterprise instance                                                                     | `nil`           |
-| `global.bitbucketEnterprise.port`       | Port of bitbucketEnterprise instance                                                                         | `nil`           |
-| `global.features.cloneSubmodules`       | Enable sharing of configuration files for the analysis tools placed on git submodules                        |                 |
-| `false`                                 |                                                                                                              |                 |
+| Parameter                                       | Description                                                                                                  | Default         |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | --------------- |
+| `global.codacy.url`                             | Hostname to your Codacy installation                                                                         | `nil`           |
+| `global.codacy.backendUrl`                      | Hostname to your Codacy installation                                                                         | `nil`           |
+| `global.play.cryptoSecret`                      | Secrets used internally for encryption. Generate one with \`openssl rand -base64 128 \| tr -dc 'a-zA-Z0-9'\` | `nil`           |
+| `global.akka.sessionSecret`                     | Secrets used internally for encryption. Generate one with \`openssl rand -base64 128 \| tr -dc 'a-zA-Z0-9'\` | `nil`           |
+| `global.filestore.contentsSecret`               | Secrets used internally for encryption. Generate one with \`openssl rand -base64 128 \| tr -dc 'a-zA-Z0-9'\` | `nil`           |
+| `global.filestore.uuidSecret`                   | Secrets used internally for encryption. Generate one with \`openssl rand -base64 128 \| tr -dc 'a-zA-Z0-9'\` | `nil`           |
+| `global.cacheSecret`                            | Secrets used internally for encryption. Generate one with \`openssl rand -base64 128 \| tr -dc 'a-zA-Z0-9'\` | `nil`           |
+| `global.minio.create`                           | Create minio internally                                                                                      | `nil`           |
+| `global.rabbitmq.create`                        | Create rabbitmq internally                                                                                   | `nil`           |
+| `global.rabbitmq.rabbitmqUsername`              | Username for rabbitmq. If you are using the bundled version, change the `rabbitmq-ha.rabbitmqUsername` also. | `nil`           |
+| `global.rabbitmq.rabbitmqPassword`              | Password for rabbitmq. If you are using the bundled version, change the `rabbitmq-ha.rabbitmqPassword` also. | `nil`           |
+| `global.defaultdb.postgresqlUsername`           | Username of the Postgresql server                                                                            | `codacy`        |
+| `global.defaultdb.postgresqlDatabase`           | Database name of the Postgresql server                                                                       | `default`       |
+| `global.defaultdb.postgresqlPassword`           | Hostname of the Postgresql server                                                                            | `nil`           |
+| `global.defaultdb.host`                         | Hostname of the Postgresql server                                                                            | `nil`           |
+| `global.defaultdb.service.port`                 | Port of the Postgresql server                                                                                | `5432`          |
+| `global.analysisdb.postgresqlUsername`          | Username of the Postgresql server                                                                            | `codacy`        |
+| `global.analysisdb.postgresqlDatabase`          | Database name of the Postgresql server                                                                       | `analysis`      |
+| `global.analysisdb.postgresqlPassword`          | Hostname of the Postgresql server                                                                            | `nil`           |
+| `global.analysisdb.host`                        | Hostname of the Postgresql server                                                                            | `nil`           |
+| `global.analysisdb.service.port`                | Port of the Postgresql server                                                                                | `5432`          |
+| `global.resultsdb.postgresqlUsername`           | Username of the Postgresql server                                                                            | `codacy`        |
+| `global.resultsdb.postgresqlDatabase`           | Database name of the Postgresql server                                                                       | `results201709` |
+| `global.resultsdb.postgresqlPassword`           | Hostname of the Postgresql server                                                                            | `nil`           |
+| `global.resultsdb.host`                         | Hostname of the Postgresql server                                                                            | `nil`           |
+| `global.resultsdb.service.port`                 | Port of the Postgresql server                                                                                | `5432`          |
+| `global.metricsdb.postgresqlUsername`           | Username of the Postgresql server                                                                            | `codacy`        |
+| `global.metricsdb.postgresqlDatabase`           | Database name of the Postgresql server                                                                       | `metrics`       |
+| `global.metricsdb.postgresqlPassword`           | Hostname of the Postgresql server                                                                            | `nil`           |
+| `global.metricsdb.host`                         | Hostname of the Postgresql server                                                                            | `nil`           |
+| `global.metricsdb.service.port`                 | Port of the Postgresql server                                                                                | `5432`          |
+| `global.filestoredb.postgresqlUsername`         | Username of the Postgresql server                                                                            | `codacy`        |
+| `global.filestoredb.postgresqlDatabase`         | Database name of the Postgresql server                                                                       | `filestore`     |
+| `global.filestoredb.postgresqlPassword`         | Hostname of the Postgresql server                                                                            | `nil`           |
+| `global.filestoredb.host`                       | Hostname of the Postgresql server                                                                            | `nil`           |
+| `global.filestoredb.service.port`               | Port of the Postgresql server                                                                                | `5432`          |
+| `global.jobsdb.postgresqlUsername`              | Username of the Postgresql server                                                                            | `codacy`        |
+| `global.jobsdb.postgresqlDatabase`              | Database name of the Postgresql server                                                                       | `jobs`          |
+| `global.jobsdb.postgresqlPassword`              | Hostname of the Postgresql server                                                                            | `nil`           |
+| `global.jobsdb.host`                            | Hostname of the Postgresql server                                                                            | `nil`           |
+| `global.jobsdb.service.port`                    | Port of the Postgresql server                                                                                | `5432`          |
+| `global.githubEnterprise.enabled`               | Enable githubEnterprise                                                                                      | `nil`           |
+| `global.githubEnterprise.hostname`              | Hostname of githubEnterprise instance                                                                        | `nil`           |
+| `global.githubEnterprise.protocol`              | Protocol of githubEnterprise instance                                                                        | `nil`           |
+| `global.githubEnterprise.port`                  | Port of githubEnterprise instance                                                                            | `nil`           |
+| `global.githubEnterprise.isPrivateMode`         | Status of private mode on githubEnterprise instance                                                          | `nil`           |
+| `global.githubEnterprise.disableSSL`            | Disable certificate validation on interaction with githubEnterprise instance                                 | `nil`           |
+| `global.gitlabEnterprise.enabled`               | Enable gitlabEnterprise                                                                                      | `nil`           |
+| `global.gitlabEnterprise.hostname`              | Hostname of gitlabEnterprise instance                                                                        | `nil`           |
+| `global.gitlabEnterprise.protocol`              | Protocol of gitlabEnterprise instance                                                                        | `nil`           |
+| `global.gitlabEnterprise.port`                  | Port of gitlabEnterprise instance                                                                            | `nil`           |
+| `global.bitbucketEnterprise.enabled`            | Enable bitbucketEnterprise                                                                                   | `nil`           |
+| `global.bitbucketEnterprise.hostname`           | Hostname of bitbucketEnterprise instance                                                                     | `nil`           |
+| `global.bitbucketEnterprise.protocol`           | Protocol of bitbucketEnterprise instance                                                                     | `nil`           |
+| `global.bitbucketEnterprise.port`               | Port of bitbucketEnterprise instance                                                                         | `nil`           |
+| `global.bitbucketEnterprise.consumerKey`        | Codacy app name to be identified on bitbucketEnterprise instance                                             | `nil`           |
+| `global.bitbucketEnterprise.consumerPublicKey`  | Public key to be set on bitbucketEnterprise instance                                                         | `nil`           |
+| `global.bitbucketEnterprise.consumerPrivateKey` | Private key to sign requests made to the bitbucketEnteprise instance                                         | `nil`           |
+| `global.features.cloneSubmodules`               | Enable sharing of configuration files for the analysis tools placed on git submodules                        | `false`         |
 
 The following parameters are specific to each Codacy component.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -39,7 +39,7 @@ Otherwise, you can find instructions here:
 3. Run `helm dep up`.
 4. Commit both `requirements.yaml` and `requirements.lock` to the branch. The commit message must be "`release: start release [DD-MM-YYYY]`".
 5. Tag the commit with `release-[DD-MM-YYYY].[buildversion]` and push.
-6. This tag will automatically trigger a release candidate build. You chart will be deployed to `k8s.release.dev.codacy.org` (`codacy-doks-cluster-release` cluster in digital ocean).
+6. This tag will automatically trigger a release candidate build. You chart will be deployed to [the release environment described in this table](./README.md) (`codacy-doks-cluster-release` cluster in digital ocean).
 7. Follow the `release` workflow of the `chart` project on circleci.
 
 ## During the release

--- a/codacy/requirements.yaml
+++ b/codacy/requirements.yaml
@@ -26,7 +26,7 @@ dependencies:
   git: git@github.com:codacy/kube-fluentd-operator.git
 
 - name: portal
-  version: ">=5.0.0"
+  version: ">=6.0.0"
   repository: https://charts.codacy.com/stable
   git: git@bitbucket.org:qamine/portal.git
 
@@ -71,7 +71,7 @@ dependencies:
   git: git@bitbucket.org:qamine/codacy-worker.git
 
 - name: codacy-api
-  version: ">=5.5.0"
+  version: ">=7.0.0"
   repository: https://charts.codacy.com/stable
   git: git@bitbucket.org:qamine/codacy-website.git
 

--- a/codacy/values.yaml
+++ b/codacy/values.yaml
@@ -45,6 +45,9 @@ global:
     # hostname: "example.host.com"
     # protocol: "http"
     # port: 7990
+    # consumerKey: ""
+    # consumerPublicKey: ""
+    # consumerPrivateKey: ""
 
   play:
     cryptoSecret: "PLEASE_CHANGE_ME" # Generate one with `cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 128 | head -n 1`

--- a/docs/configuration/git-providers/bitbucket-enterprise.md
+++ b/docs/configuration/git-providers/bitbucket-enterprise.md
@@ -1,15 +1,25 @@
-# Bitbucket Stash
+# Bitbucket Server
 
 Set your configuration values for your Bitbucket instance on the `values.yaml` file.
+
+**NOTE:** Since Bitbucket Server uses OAuth1, you'll need to create a key pair to sign and validate the requests between Codacy and the Bitbucket Server instance:
+
+1. Create the key pair by running the command below, making sure that you don't define a passphrase:
+
+   `ssh-keygen -t rsa -f mykey -q -N ""`
+
+1.  Copy the private key from the `mykey` file and set it in the `consumerPrivateKey`.
+1.  Copy the public key from the `mykey.pub` file and set it in the `consumerPublicKey`. 
+
 **Please note that you must go to `http://codacy.example.com/admin/integrations`, select the desired provider and `Test & Save` your configuration for it to be applied.**
 
 Go to `admin/integration` on Codacy and set the **Project Keys** on the Bitbucket Server integration, these should be the keys of the projects you would like to retrieve repositories of.
 
 ![Stash Application Link](./images/stash-application-link.png)
 
-## Stash Application Link
+## Bitbucket Server Application Link
 
-To set up Stash you need to create an application link on your Stash installation.
+To set up Bitbucket Server you need to create an application link on your Bitbucket Server installation.
 You can click on here and go to the application links list.
 
 ### Application Link Creation


### PR DESCRIPTION
We no longer need to patch this worker version if we expose it through the makefile.
The default version is the stable tag.