### PR TITLE
Change log format and output [CY-1138]

### DIFF
--- a/codacy/requirements-dev.yaml
+++ b/codacy/requirements-dev.yaml
@@ -19,7 +19,7 @@ dependencies:
     global.metricsdb.create, global.filestoredb.create, global.jobsdb.create
 
 - name: log-router
-  version: 0.3.0
+  version: 0.4.1
   repository: https://charts.codacy.com/external
   condition: fluentdoperator.enabled
   alias: fluentdoperator

--- a/codacy/requirements.lock
+++ b/codacy/requirements.lock
@@ -10,10 +10,10 @@ dependencies:
   version: 4.2.2
 - name: log-router
   repository: https://charts.codacy.com/external
-  version: 0.3.0
+  version: 0.4.1
 - name: codacy-ingress
   repository: https://charts.codacy.com/stable
-  version: 0.2.0
+  version: 0.1.1
 - name: portal
   repository: https://charts.codacy.com/stable
   version: 6.6.1
@@ -25,7 +25,7 @@ dependencies:
   version: 1.4.0
 - name: remote-provider-service
   repository: https://charts.codacy.com/stable
-  version: 8.0.2
+  version: 8.0.1
 - name: hotspots-api
   repository: https://charts.codacy.com/stable
   version: 1.4.1
@@ -49,6 +49,6 @@ dependencies:
   version: 9.1.0
 - name: crow
   repository: https://charts.codacy.com/stable
-  version: 4.9.1
-digest: sha256:813751de7ef84e71059695ef401923927e368bceeade26dc591128d9db40b5c9
-generated: "2020-03-18T11:43:54.873856Z"
+  version: 4.9.0
+digest: sha256:43b5865aa397cdf75a22ec28e1a10d3ad5c77496863e4327c8c19fb3962d3ef4
+generated: "2020-03-17T17:42:05.70650814Z"

--- a/codacy/requirements.lock
+++ b/codacy/requirements.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 0.4.1
 - name: codacy-ingress
   repository: https://charts.codacy.com/stable
-  version: 0.1.1
+  version: 0.2.0
 - name: portal
   repository: https://charts.codacy.com/stable
   version: 6.6.1
@@ -25,7 +25,7 @@ dependencies:
   version: 1.4.0
 - name: remote-provider-service
   repository: https://charts.codacy.com/stable
-  version: 8.0.1
+  version: 8.0.2
 - name: hotspots-api
   repository: https://charts.codacy.com/stable
   version: 1.4.1
@@ -49,6 +49,6 @@ dependencies:
   version: 9.1.0
 - name: crow
   repository: https://charts.codacy.com/stable
-  version: 4.9.0
-digest: sha256:43b5865aa397cdf75a22ec28e1a10d3ad5c77496863e4327c8c19fb3962d3ef4
-generated: "2020-03-17T17:42:05.70650814Z"
+  version: 4.9.1
+digest: sha256:5a79fb5b0f216c8b41db66f4d8bd59791d141f991af0143381b50d2ac7207741
+generated: "2020-03-18T14:14:17.132638874Z"

--- a/codacy/requirements.yaml
+++ b/codacy/requirements.yaml
@@ -19,7 +19,7 @@ dependencies:
     global.metricsdb.create, global.filestoredb.create, global.jobsdb.create
 
 - name: log-router
-  version: 0.3.0
+  version: 0.4.1
   repository: https://charts.codacy.com/external
   condition: fluentdoperator.enabled
   alias: fluentdoperator

--- a/codacy/templates/fluentd/fluentd-conf.yaml
+++ b/codacy/templates/fluentd/fluentd-conf.yaml
@@ -17,47 +17,62 @@ data:
     <filter **>
       @type record_modifier
       <record>
-        # This removes unneeded fields from the logs
         for_remove ${record["kubernetes"].delete("namespace_name"); record["kubernetes"].delete("pod_id"); record["kubernetes"].delete("namespace_labels"); record["kubernetes"].delete("container_info"); record["kubernetes"].delete("labels"); record.delete("container_info"); record.delete("docker")}
       </record>
+      # This removes unneeded fields from the logs
       remove_keys for_remove
+    </filter>
+
+    # Move mested records to toplevel to be used as buffer key
+    <filter **>
+      @type record_modifier
+      <record>
+        pod_name ${record["kubernetes"]["pod_name"]}
+      </record>
+      <record>
+        container_name ${record["kubernetes"]["container_name"]}
+      </record>
     </filter>
 
     # Output to S3
     <match **>
-      # docs: https://github.com/fluent/fluent-plugin-s3 and https://docs.fluentd.org/output/s3
+      # Docs: https://github.com/fluent/fluent-plugin-s3
       @type s3
       @log_level info
 
+      # Credentials
       aws_key_id {{ .Values.global.minio.accessKey }}
       aws_sec_key {{ .Values.global.minio.secretKey }}
 
+      # Bucket configuration
       s3_endpoint http://{{ .Values.global.minio.location }}:9000
-      force_path_style true # This prevents AWS SDK from breaking endpoint URL for minio
       s3_bucket {{ .Values.fluentdoperator.bucketName }}
+      force_path_style true # This prevents AWS SDK from breaking endpoint URL for minio
       auto_create_bucket true
 
-      #s3_object_key_format %{path}%Y/%m/%d/cluster-log-%{index}.%{file_extension}
-
-      path ${tag}/%Y/%m/%d/
-      s3_object_key_format %{path}%{index}.%{file_extension}
+      # Output location configuration
+      path ${container_name}/${pod_name}/%Y-%m-%d
+      s3_object_key_format %{path}_%{index}.%{file_extension}
 
       <bucket_lifecycle_rule>
         id retention-policy
         expiration_days {{ .Values.fluentdoperator.expirationDays }}
       </bucket_lifecycle_rule>
 
+      store_as json
       <format>
         @type json
       </format>
 
-      <buffer tag,time>
+      # Check https://docs.fluentd.org/plugin-development/api-plugin-output
+      <buffer tag,time,container_name,pod_name>
         @type file
         path /var/log/fluentd-buffers/s3.buffer
-        timekey 600 # Time frames of 10 minutes
-        timekey_wait 0 # We want to send the logs from the timeframe to s3 as soon as possible
+        timekey 6h
+        timekey_wait 0s
         timekey_use_utc true
-        chunk_limit_size 256m
+        flush_interval 0s
+        flush_mode interval
       </buffer>
     </match>
 {{ end }}

--- a/codacy/templates/fluentd/fluentd-conf.yaml
+++ b/codacy/templates/fluentd/fluentd-conf.yaml
@@ -23,7 +23,7 @@ data:
       remove_keys for_remove
     </filter>
 
-    # Move mested records to toplevel to be used as buffer key
+    # Move nested records to toplevel to be used as buffer key
     <filter **>
       @type record_modifier
       <record>
@@ -65,13 +65,20 @@ data:
       </format>
 
       # Check https://docs.fluentd.org/plugin-development/api-plugin-output
-      <buffer tag,time,container_name,pod_name>
+      # This plugin only implemens [async buffered mode](https://docs.fluentd.org/plugin-development/api-plugin-output#async-buffered-mode)
+      # With the current state this config means every time it writes to s3 it will [create a new file](https://github.com/fluent/fluent-plugin-s3/blob/50e4dc930ac8a5e5434382ad1365c58b9357221c/lib/fluent/plugin/out_s3.rb#L351),
+      #   not respecting the `timekey`. The only way to not have infinite files is to have a "reasonable" `timekey`.
+      #   Independently of how reasonable the `timekey` is, it might create problems when users report issues, since the actions they make in the UI might take at least `timekey` to be relfected in the log files.
+      # TLDR:
+      #   - `timekey_wait` seems to only add a wait before writting to the existing `timekey`
+      #   - `timekey` and `flush_interval` in the explained conditions above seem to have the exact same behaviour, the lower one will decide the partitioning
+      <buffer time,container_name,pod_name>
         @type file
         path /var/log/fluentd-buffers/s3.buffer
-        timekey 6h
+        timekey 60s
         timekey_wait 0s
         timekey_use_utc true
-        flush_interval 0s
+        flush_interval 60s
         flush_mode interval
       </buffer>
     </match>

--- a/codacy/templates/fluentd/fluentd-conf.yaml
+++ b/codacy/templates/fluentd/fluentd-conf.yaml
@@ -19,7 +19,7 @@ data:
       <record>
         for_remove ${record["kubernetes"].delete("namespace_name"); record["kubernetes"].delete("pod_id"); record["kubernetes"].delete("namespace_labels"); record["kubernetes"].delete("container_info"); record["kubernetes"].delete("labels"); record.delete("container_info"); record.delete("docker")}
       </record>
-      # This removes unneeded fields from the logs
+      # This removes the fields defined in `for_remove` from the logs
       remove_keys for_remove
     </filter>
 


### PR DESCRIPTION
TLDR:
After a long debug with the help of @DReigada we found that microk8s had no logs due to parsing issues.

The problem was basically that k8s writes logs in json while microk8s does not.
The parser is fluentd operator was not ready and needed some changes, which were already upstream in the vmware repo.

We issued a bump https://github.com/codacy/kube-fluentd-operator/pull/6 and it seems to work now.

Also two PRs were open: https://github.com/vmware/kube-fluentd-operator/pull/81 and https://github.com/vmware/kube-fluentd-operator/pull/104 to make sure we eventually remove the fork.