### PR TITLE
Organize table of contents

### DIFF
--- a/docs/extra/database.md
+++ b/docs/extra/database.md
@@ -1,4 +1,4 @@
-# Database Migration Guide
+# Database migration guide
 
 Migrating databases between pods is a straightforward process with 3 steps:
 

--- a/docs/extra/k8s-cheatsheet.md
+++ b/docs/extra/k8s-cheatsheet.md
@@ -1,4 +1,4 @@
-# Kubernetes Cheatsheet
+# Kubernetes cheatsheet
 
 ## How to install a custom Codacy version
 
@@ -20,7 +20,7 @@ helm upgrade --install codacy ./chart/codacy/ --namespace codacy --atomic --time
 
 ## Clean the namespace
 
-```
+```bash
 helm del --purge codacy
 kubectl -n codacy delete --all pod &
 kubectl -n codacy delete --all pvc &
@@ -38,6 +38,7 @@ kubectl -n codacy get job &
 ```
 
 ### Check uninstall was successful
+
 ```bash
 ps aux | grep -i kubectl
 ```
@@ -79,7 +80,6 @@ kubectl get daemonsets
 ```bash
 kubectl rollout restart daemonset/<daemonset-name>
 ```
-
 
 ### deployment
 
@@ -125,7 +125,7 @@ kubectl exec -it daemonset/<daemonset-name> -c <container-name> sh
 kubectl exec -it deployment/<deployment-name> sh
 ```
 
-## microk8s
+## MicroK8s
 
 ### Session Manager SSH
 

--- a/docs/extra/uninstall.md
+++ b/docs/extra/uninstall.md
@@ -1,4 +1,4 @@
-# Uninstall
+# Uninstalling Codacy
 
 To ensure a clean removal you should uninstall Codacy before destroying the cluster.
 To do so run:

--- a/docs/extra/upgrade.md
+++ b/docs/extra/upgrade.md
@@ -1,24 +1,23 @@
-# Upgrade
+# Upgrading Codacy
 
-NOTE: **Note:**
+**NOTE:**
 You can retrieve your previous `--set` arguments cleanly, with
 `helm get values <release name>`. If you direct this into a file
 (`helm get values <release name> > codacy.yaml`), you can safely pass this
-file via `-f`. Thus `helm upgrade codacy codacy/codacy -f codacy.yaml`.
+file via `-f`, like `helm upgrade codacy codacy/codacy -f codacy.yaml`.
 This safely replaces the behavior of `--reuse-values`
-
-## Steps
 
 The following are the steps to upgrade Codacy to a newer version:
 
-1.  Extract your previous `--set` arguments with
+1. Extract your previous `--set` arguments with:
 
     ```bash
     helm get values codacy > codacy.yaml
     ```
 
-2.  Decide on all the values you need to set
-3.  Perform the upgrade, with all `--set` arguments extracted in step 2
+2. Decide on all the values you need to set.
+
+3. Perform the upgrade, with all `--set` arguments extracted in step 2:
 
     ```bash
     helm upgrade codacy codacy/codacy \

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,12 +38,12 @@ markdown_extensions:
 nav:
   - index.md
   - requirements.md
-  - "1. Setting up the Kubernetes infrastructure":
+  - "Setting up the Kubernetes infrastructure":
     - infrastructure/eks-quickstart.md
     - infrastructure/aks-quickstart.md
     - infrastructure/microk8s-quickstart.md
-  - "2. Installing Codacy": install.md
-  - "3. Post-install configuration":
+  - install.md
+  - "Post-install configuration":
     - configuration/git-providers/github-cloud.md
     - configuration/git-providers/github-enterprise.md
     - configuration/git-providers/gitlab-enterprise.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,3 +33,25 @@ markdown_extensions:
 - pymdownx.superfences
 - toc:
     permalink: true
+
+# Table of contents
+nav:
+  - index.md
+  - requirements.md
+  - "1. Setting up the Kubernetes infrastructure":
+    - infrastructure/eks-quickstart.md
+    - infrastructure/aks-quickstart.md
+    - infrastructure/microk8s-quickstart.md
+  - "2. Installing Codacy": install.md
+  - "3. Post-install configuration":
+    - configuration/git-providers/github-cloud.md
+    - configuration/git-providers/github-enterprise.md
+    - configuration/git-providers/gitlab-enterprise.md
+    - configuration/git-providers/bitbucket-enterprise.md
+    - configuration/logging.md
+    - configuration/monitoring.md
+  - "Extra":
+    - extra/upgrade.md
+    - extra/uninstall.md
+    - extra/database.md
+    - extra/k8s-cheatsheet.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,19 +1,29 @@
+# Project information
 site_name: "Codacy Chart"
-use_directory_urls: true
+
+# Configuration
 theme:
   logo: 'images/codacy-logo.svg'
   name: 'material'
   palette:
     primary: 'indigo'
     accent: 'indigo'
+
 extra_css:
   - 'stylesheets/extra.css'
 extra_javascript:
   - 'javascripts/extra.js'
-copyright: "Codacy"
+
 strict: true
+use_directory_urls: true
+
+# Copyright
+copyright: '© <a href="https://www.codacy.com/">Codacy</a>'
+
+# Plugins and extensions
 plugins:
 - search
+
 markdown_extensions:
 - admonition
 - codehilite


### PR DESCRIPTION
I'm adding an explicit navigation structure to the `mkdocs.yml` file so that the table of contents displayed on the sidebar of the generated pages follows the logical order of the installation instructions.