### PR TITLE
Update .remarkrc

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -1,6 +1,10 @@
 {
-  "settings": {
-    "listItemIndent": "1",
-    "bullet": "*"
-  }
+  "plugins": [
+    "preset-lint-consistent",
+    "preset-lint-recommended",
+    "lint-heading-increment",
+    [
+      "lint-unordered-list-marker-style", "-"
+    ]
+  ]
 }


### PR DESCRIPTION
The Visual Studio Code extension [Remark](https://marketplace.visualstudio.com/items?itemName=mrmlnc.vscode-remark) uses [remark-stringify](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify) to beautify / reformat Markdown.

However, this tool uses defaults that do not necessarily match the configuration of the [remark-lint](https://github.com/remarkjs/remark-lint) Markdown code style linter, which has many [rules](https://github.com/remarkjs/remark-lint/blob/master/doc/rules.md#list-of-rules) and [presets](https://github.com/remarkjs/remark-lint#list-of-presets) to choose from.

As such, I'm configuring remark-lint to match the defaults of remark-stringify instead of trying to configure remark-stringify with better options. This is because, as far as I could understand, the configuration settings for remark-stringify are much more limited and were causing problems (namely with the identation of content inside list items).