### PR TITLE
fix: get all logs associated with a service

### DIFF
--- a/docs/extra/k8s-cheatsheet.md
+++ b/docs/extra/k8s-cheatsheet.md
@@ -42,18 +42,6 @@ kubectl -n codacy get job &
 ps aux | grep -i kubectl
 ```
 
-## Get logs of a service
-
-```bash
-kubectl get services
-```
-
-**and**
-
-```bash
-kubectl logs svc/<service-name>
-```
-
 ## Edit configmap
 
 ```bash
@@ -110,7 +98,13 @@ kubectl logs daemonset/<daemonset-name> <container-name> -f
 ### service
 
 ```bash
-kubectl logs service/<service-name> -f
+kubectl get svc
+```
+
+**and**
+
+```bash
+kubectl logs -l $(kubectl get svc/<service-name> -o=json | jq ".spec.selector" | jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' | sed -e 'H;${x;s/\n/,/g;s/^,//;p;};d') -f
 ```
 
 ## Open shell inside container


### PR DESCRIPTION
If you do just `kubectl logs svc/<service-name>` you don't get the logs of every pod associated with the service. 

You can try with this example:
```yaml
# test-logs.yaml
apiVersion: v1
kind: Service
metadata:
  name: hello-kubernetes
spec:
  type: LoadBalancer
  ports:
  - port: 80
    targetPort: 8080
  selector:
    app: hello-kubernetes
    app2: another-label
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: hello-kubernetes
spec:
  replicas: 3
  selector:
    matchLabels:
      app: hello-kubernetes
  template:
    metadata:
      labels:
        app: hello-kubernetes
        app2: another-label
    spec:
      containers:
      - name: hello-kubernetes
        image: debian
        ports:
        - containerPort: 8080
        command: ["bin/bash"]
        args: ["-c","while true; do sleep 3; echo \"hello from `hostname -i`\"; done"]
```

If you put this on a file called `test-logs.yaml`, do `kubectl apply -f <test-logs.yaml>` and then `kubectl logs -f svc/hello-kubernetes` you get the following message in the start:
`Found 3 pods, using pod/hello-kubernetes-6dcb55447-dlwb7`

Which means that you will only get the logs from one of the pods.

To get the logs for all the pods you have to use the labels of the pod, the ones that are used on the selector of the service. Or, in alternative, you can a use a tool like [kubetail](https://github.com/johanhaleby/kubetail) to get the logs of multiple pods.