### PR TITLE
Change "Release notes" to "Changelog"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,7 +329,7 @@ jobs:
           message: |
             Version $(cat .version) of the Codacy chart has been released!
             Release on GitHub: https://github.com/codacy/chart/releases/tag/$(cat .version)
-            Release notes: https://github.com/codacy/chart/releases/download/$(cat .version)/changelog.md
+            Changelog: https://github.com/codacy/chart/releases/download/$(cat .version)/changelog.md
 
   publish_changelog_to_github:
     <<: *default_doks_image


### PR DESCRIPTION
Hi @joaocosta-codacy,

While I was updating [this slide](https://docs.google.com/presentation/d/16-Q55ck-cbW3cttBzP-hTtJQT3lZmyTKFKsgcQdxSrM/edit#slide=id.g6de0b732e5_0_149) I remembered that I had seen "Release notes" instead of "Changelog" somewhere in the scripts for creating / uploading the Chart 
changelogs. So I went back and noticed I had made a mistake in the suggestion for the Slack notify message! :smile: 

Let's change it to "Changelog", as the release notes are a different thing.