### PR TITLE
Update mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 # Project information
-site_name: codacy/chart
+site_name: Chart
 site_url: https://codacy.github.io/chart/
 
 # Configuration

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 # Project information
-site_name: "Codacy Chart"
+site_name: codacy/chart
 site_url: https://codacy.github.io/chart/
 
 # Configuration


### PR DESCRIPTION
Changing name to follow mkdocs convention. "Site name can only contain letters, numbers, underscores, hyphens and forward-slashes. The regular expression we test against is '^[a-zA-Z0-9_\-/]+$'."

This is required for codacy/docs#5 where we're trying to include this repo into the future docs of Codacy.