### PR TITLE
fix: added missing config tag

### DIFF
--- a/codacy/values-microk8s.yaml
+++ b/codacy/values-microk8s.yaml
@@ -58,6 +58,7 @@ worker-manager:
   resources:
     limits:
       memory: 500Mi
+  config:
     workerResources:
       limits:
         memory: "2Gi"


### PR DESCRIPTION
This config field was missing from the yaml.
I caught this while testing helm 3, which was complaining about the fact that `workerResources` was not a valid field. I went to check `worker-manager` and found out this discrepancy.