### PR TITLE
Sandbox/lower timeout

### DIFF
--- a/.doks/Makefile
+++ b/.doks/Makefile
@@ -9,7 +9,7 @@ SHELL := /bin/bash # we need this for the extra args in `call_helm_install`
 
 define rotate_pod
   kubectl patch deployment $(strip $(1)) -n ${NAMESPACE} -p '{"spec":{"template":{"metadata":{"annotations":{"date": "'$(shell date +'%Y-%m-%dT%H:%M:%S')'" }}}}}';
-  kubectl rollout status "deployment/$(strip $(1))" -n ${NAMESPACE} --watch --timeout=30m &
+  kubectl rollout status "deployment/$(strip $(1))" -n ${NAMESPACE} --watch --timeout=10m &
 endef
 
 define call_helm_install

--- a/.doks/Makefile
+++ b/.doks/Makefile
@@ -16,7 +16,7 @@ define call_helm_install
 	eval "extra_args=($$HELM_INSTALL_EXTRA_FLAGS)"; \
 	helm upgrade --install ${1} ${3} \
 	--atomic \
-	--timeout=1800 \
+	--timeout=600 \
 	-f values.yaml \
 	--namespace ${2} \
 	--set global.imagePullSecrets[0].name=docker-credentials \


### PR DESCRIPTION
These timeouts can be lowered now that we are not using recreate-pods (it used to be the operation that took the biggest chunk of time).
In turn this will help the workflows that call deploying to dev sh. Since the timeout is lower, if something goes wrong the helm rollback will be quicker so the workflows will fail quicker too. (10m vs 30m)