### PR TITLE
Add bitbucket.md to the mkdocs.yaml navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ nav:
     - configuration/git-providers/create-github-app.md
     - configuration/git-providers/gitlab-cloud.md
     - configuration/git-providers/gitlab-enterprise.md
+    - configuration/git-providers/bitbucket.md
     - configuration/git-providers/bitbucket-server.md
     - configuration/git-providers/create-bitbucket-server-application-link.md
     - configuration/monitoring.md


### PR DESCRIPTION
This is necessary so that the new page appears on the table of contents sidebar of the generated HTML pages.