### PR TITLE
Fix "enabled" value string

### DIFF
--- a/docs/configuration/git-providers/github-cloud.md
+++ b/docs/configuration/git-providers/github-cloud.md
@@ -8,7 +8,7 @@ Follow the instructions below to set up the Codacy integration with GitHub Cloud
 
     ```yaml
     github:
-      enabled: true
+      enabled: "true"
       clientId: Iv1.0000000000000000 # Client ID
       clientSecret: a000000000000000 # Client secret
       app:

--- a/docs/configuration/git-providers/github-enterprise.md
+++ b/docs/configuration/git-providers/github-enterprise.md
@@ -8,7 +8,7 @@ Follow the instructions below to set up the Codacy integration with GitHub Enter
 
     ```yaml
     githubEnterprise:
-      enabled: true
+      enabled: "true"
       hostname: example.host.com # Hostname of your GitHub Enterprise instance
       port: 443 # Port of your GitHub Enterprise instance
       protocol: https # Protocol of your GitHub Enterprise instance

--- a/docs/configuration/git-providers/gitlab-cloud.md
+++ b/docs/configuration/git-providers/gitlab-cloud.md
@@ -19,7 +19,7 @@ Follow the instructions below to set up the Codacy integration with GitLab Cloud
 
     ```yaml
     gitlab:
-      enabled: true
+      enabled: "true"
       clientId: a000000000000000 # Client ID
       clientSecret: a000000000000000 # Client secret
     ```


### PR DESCRIPTION
Apparently Codacy does not deal well with the value of this key unless
it's surrounded by quotes.