### PR TITLE
Revert to asking users to remove newlines from their private keys

### DIFF
--- a/docs/configuration/integrations/github-cloud.md
+++ b/docs/configuration/integrations/github-cloud.md
@@ -14,9 +14,7 @@ Follow the instructions below to set up the Codacy integration with GitHub Cloud
       app:
         name: Codacy # GitHub App name
         id: 00000 # App ID
-        privateKey: >
-          -----BEGIN RSA PRIVATE KEY-----
-          # Private key (contents of the .pem file)
+        privateKey: "-----BEGIN RSA PRIVATE KEY-----..." # Contents of the .pem file with newlines removed
           -----END RSA PRIVATE KEY-----
     ```
 

--- a/docs/configuration/integrations/github-enterprise.md
+++ b/docs/configuration/integrations/github-enterprise.md
@@ -19,10 +19,7 @@ Follow the instructions below to set up the Codacy integration with GitHub Enter
       app:
         name: Codacy # GitHub App name
         id: 00000 # App ID
-        privateKey: >
-          -----BEGIN RSA PRIVATE KEY-----
-          # Private key (contents of the .pem file)
-          -----END RSA PRIVATE KEY-----
+        privateKey: "-----BEGIN RSA PRIVATE KEY-----..." # Contents of the .pem file with newlines removed
     ```
 
 3.  Apply this configuration by performing a Helm upgrade. To do so append `--values values-production.yaml` to the command [used to install Codacy](../../index.md#2-installing-codacy):


### PR DESCRIPTION
When trying to use the `values-production.yaml` file with the private key using a multiline syntax the Helm upgrade fails:

```
Exception in thread "main" java.lang.IllegalArgumentException: Illegal base64 character 20
	at java.util.Base64$Decoder.decode0(Base64.java:714)
	at java.util.Base64$Decoder.decode(Base64.java:526)
	at java.util.Base64$Decoder.decode(Base64.java:549)
	at com.codacy.remote.provider.service.configuration.utils.PrivateKeyLoader$.loadFromString(PrivateKeyLoader.scala:27)
	at com.codacy.remote.provider.service.configuration.GitHubConfigurationFactory$$anonfun$apply$2.applyOrElse(GitHubConfiguration.scala:19)
	at com.codacy.remote.provider.service.configuration.GitHubConfigurationFactory$$anonfun$apply$2.applyOrElse(GitHubConfiguration.scala:14)
	at scala.PartialFunction$Lifted.apply(PartialFunction.scala:228)
	at scala.PartialFunction$Lifted.apply(PartialFunction.scala:224)
	at scala.Option.collect(Option.scala:432)
	at com.codacy.remote.provider.service.configuration.GitHubConfigurationFactory$.apply(GitHubConfiguration.scala:14)
	at com.codacy.remote.provider.service.configuration.ApiConfigurationFactory$.apply(ApiConfigurationFactory.scala:16)
	at com.codacy.remote.provider.service.configuration.ConfigurationComponents.<init>(ConfigurationComponents.scala:7)
	at com.codacy.remote.provider.service.Main$.main(Main.scala:39)
	at com.codacy.remote.provider.service.Main.main(Main.scala)
```