### PR TITLE
feature: Bump codacy-orbs to have helm3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/base@2.9.1
+  codacy: codacy/base@4.0.0
   slack: circleci/slack@3.4.2
 
 references:


### PR DESCRIPTION
This is needed for the nightly builds with helm3