### PR TITLE
fix: Update cluster entries on docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,9 +245,9 @@ All of them serve different purposes.
 
 | Installation | Cluster                 | Namespace      | Purpose                                                                                                                    | Url                                 |
 | ------------ | ----------------------- | -------------- | -------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-| Dev          | codacy-doks-cluster-dev | codacy         | Updated automatically on each component pipeline. Rolling release of [unstable](https://charts.codacy.com/unstable/api)    | <http://dev.k8s.dev.codacy.org>     |
-| Sandbox      | codacy-doks-cluster-dev | codacy-hourly  | Used for development. Manually updated. Check out [this](#deploy-your-version-of-a-component) process on how to update it. | <http://sandbox.k8s.dev.codacy.org> |
-| Release      | codacy-doks-cluster-dev | codacy-release | Used for releases. Updated when the process on the [RELEASE.md](./RELEASE.md) is triggered.                                | <http://release.k8s.dev.codacy.org> |
+| Dev          | codacy-doks-cluster     | codacy-dev     | Updated automatically on each component pipeline. Rolling release of [unstable](https://charts.codacy.com/unstable/api)    | <http://dev.k8s.dev.codacy.org>     |
+| Sandbox      | codacy-doks-cluster     | codacy-sandbox | Used for development. Manually updated. Check out [this](#deploy-your-version-of-a-component) process on how to update it. | <http://sandbox.k8s.dev.codacy.org> |
+| Release      | codacy-doks-cluster     | codacy-release | Used for releases. Updated when the process on the [RELEASE.md](./RELEASE.md) is triggered.                                | <http://release.k8s.dev.codacy.org> |
 
 ### Set up your environment for DigitalOcean clusters
 
@@ -274,10 +274,10 @@ $ doctl auth init
 
 #### 3. Setup your kubecontext for the target
 
-Replace the `<codacy-doks-cluster-dev>` with the name of your target cluster.
+Replace the `<codacy-doks-cluster>` with the name of your target cluster.
 
 ```bash
-$ doctl kubernetes cluster kubeconfig save <codacy-doks-cluster-dev> --set-current-context
+$ doctl kubernetes cluster kubeconfig save <codacy-doks-cluster> --set-current-context
 ```
 
 ## Deploy your version of a component


### PR DESCRIPTION
After the helm3 upgrade, both the cluste rname and some namespaces will have changed to a more standard nomenclature.