### PR TITLE
fix: changed git command that generates .version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,7 +225,7 @@ jobs:
       - run:
           name: setup version from git tag
           command: |
-            git describe --tags --abbrev=0 > .version
+            git tags --sort creatordate | grep -v "RC" | tail -n -1 > .version
             echo $(cat .version)
       - <<: *persist_to_workspace
 


### PR DESCRIPTION
The previous command was always returning 0.4.0 tag for unknown reasons.

With this change we fetch the latest tag (by creatordate) minus any RC tags.