### PR TITLE
fix: Add crow url to the microk8s installation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,9 @@ references:
           contentsSecret: "TEST_STRING"
           uuidSecret: "TEST_STRING"
         cacheSecret: "TEST_STRING"
+        codacy:
+          crow:
+            url: "http://localhost:9000"
       listener:
         persistence:
           claim:


### PR DESCRIPTION
It is only set on our values + makefile workflow, was not set for microk8s