### PR TITLE
Feature: Upgrade docs to Helm v3

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -43,7 +43,7 @@ Install Codacy on an existing cluster using our Helm chart:
         !!! important
             **If you are using MicroK8s** you don't need to install kubectl because you will execute all `kubectl` commands as `microk8s.kubectl` commands instead. To simplify this, [check how to create an alias](infrastructure/microk8s-quickstart.md#notes-on-installing-codacy) for `kubectl`.
 
-    -   [Helm client](https://v2.helm.sh/docs/using_helm/#installing-helm) version 2.16.3
+    -   [Helm](https://helm.sh/docs/intro/install/) version 3.2
 
 2.  Create a cluster namespace called `codacy` that will group all resources related to Codacy.
 
@@ -77,7 +77,7 @@ Install Codacy on an existing cluster using our Helm chart:
 
     !!! important
         **If you are using MicroK8s** you must use the file `values-microk8s.yaml` together with the file `values-production.yaml`.
-        
+
         Use `wget` to download the extra file and uncomment the last line before running the `helm upgrade` command below:
 
         ```bash

--- a/docs/infrastructure/microk8s-quickstart.md
+++ b/docs/infrastructure/microk8s-quickstart.md
@@ -83,10 +83,13 @@ Now that MicroK8s is running on the machine we can proceed to enabling the neces
     microk8s.config > ~/.kube/config
     ```
 
-5.  Install Helm vervsion 3.2.0:
+5.  Install Helm version 3.2.1:
 
     ```bash
-    sudo snap install helm --classic --channel=3.2/stable
+    curl -L "https://get.helm.sh/helm-v3.2.1-linux-amd64.tar.gz" | tar -zxf - &&
+    mv linux-amd64/helm /usr/local/bin/helm &&
+    chmod +x /usr/local/bin/helm &&
+    rm -r linux-amd64
     ```
 
 6.  The addons are now enabled and the MicroK8s instance bootstrapped. However, we must wait for some MicroK8s pods to be ready, as failing to do so can result in the pods entering a `CrashLoopBackoff` state:

--- a/docs/infrastructure/microk8s-quickstart.md
+++ b/docs/infrastructure/microk8s-quickstart.md
@@ -87,8 +87,8 @@ Now that MicroK8s is running on the machine we can proceed to enabling the neces
 
     ```bash
     curl -L "https://get.helm.sh/helm-v3.2.1-linux-amd64.tar.gz" | tar -zxf - &&
-    mv linux-amd64/helm /usr/local/bin/helm &&
-    chmod +x /usr/local/bin/helm &&
+    sudo mv linux-amd64/helm /usr/local/bin/helm &&
+    sudo chmod +x /usr/local/bin/helm &&
     rm -r linux-amd64
     ```
 

--- a/docs/infrastructure/microk8s-quickstart.md
+++ b/docs/infrastructure/microk8s-quickstart.md
@@ -4,10 +4,7 @@
 
 Follow the instructions below to set up a MicroK8s instance from scratch, including all the necessary dependencies and configurations.
 
-As part of this process, the Helm client (`helm`) and the Helm server (`tiller`) will be installed on the MicroK8s instance:
-
--   `helm` is the command-line client responsible for resolving the configuration of the chart to be installed and issuing the correct install commands onto the Helm server.
--   `tiller` is the in-cluster server responsible for receiving the install commands issued by the Helm client and managing the lifecycle of the components that have been installed.
+As part of this process, Helm will be installed on the MicroK8s instance.
 
 ## 1. Prepare your environment
 
@@ -46,7 +43,7 @@ Install MicroK8s on the machine:
 
 ## 3. Configuring MicroK8s
 
-Now that MicroK8s is running on the machine we can proceed to enabling the necessary addons and installing the Helm client and server:
+Now that MicroK8s is running on the machine we can proceed to enabling the necessary addons and installing Helm:
 
 1.  Configure MicroK8s to allow privileged containers:
 
@@ -80,18 +77,16 @@ Now that MicroK8s is running on the machine we can proceed to enabling the neces
     microk8s.status --wait-ready
     ```
 
-4.  Install version v2.16.3 of the Helm client:
+4.  Export your kubeconfig so that Helm knows on which cluster to install the charts:
 
     ```bash
-    sudo snap install helm --classic --channel=2.16/stable
+    microk8s.config > ~/.kube/config
     ```
 
-5.  Install the Helm server:
+5.  Install Helm vervsion 3.2.0:
 
     ```bash
-    microk8s.kubectl create serviceaccount --namespace kube-system tiller
-    microk8s.kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
-    helm init --service-account tiller
+    sudo snap install helm --classic --channel=3.2/stable
     ```
 
 6.  The addons are now enabled and the MicroK8s instance bootstrapped. However, we must wait for some MicroK8s pods to be ready, as failing to do so can result in the pods entering a `CrashLoopBackoff` state:
@@ -101,7 +96,6 @@ Now that MicroK8s is running on the machine we can proceed to enabling the neces
     microk8s.kubectl wait -n kube-system --for=condition=Ready pod -l k8s-app=hostpath-provisioner
     # If the following command fails, you probably installed the wrong MicroK8s version
     microk8s.kubectl wait -n default --for=condition=Ready pod -l name=nginx-ingress-microk8s
-    microk8s.kubectl -n kube-system wait --for=condition=Ready pod -l name=tiller
     ```
 
 7.  Verify that the MicroK8s configuration was successful:

--- a/docs/infrastructure/microk8s-quickstart.md
+++ b/docs/infrastructure/microk8s-quickstart.md
@@ -86,10 +86,9 @@ Now that MicroK8s is running on the machine we can proceed to enabling the neces
 5.  Install Helm version 3.2.1:
 
     ```bash
-    curl -L "https://get.helm.sh/helm-v3.2.1-linux-amd64.tar.gz" | tar -zxf - &&
-    sudo mv linux-amd64/helm /usr/local/bin/helm &&
-    sudo chmod +x /usr/local/bin/helm &&
-    rm -r linux-amd64
+    curl -L "https://get.helm.sh/helm-v3.2.1-linux-amd64.tar.gz" | tar -zxf - linux-amd64/helm && \
+    sudo chmod +x ./helm && \
+    sudo mv ./helm /usr/local/bin/helm
     ```
 
 6.  The addons are now enabled and the MicroK8s instance bootstrapped. However, we must wait for some MicroK8s pods to be ready, as failing to do so can result in the pods entering a `CrashLoopBackoff` state:

--- a/docs/maintenance/uninstall.md
+++ b/docs/maintenance/uninstall.md
@@ -4,7 +4,7 @@ To ensure a clean removal you should uninstall Codacy before destroying the clus
 To do so run:
 
 ```bash
-helm del --purge codacy
+helm -n codacy uninstall codacy
 kubectl -n codacy delete --all pod &
 kubectl -n codacy delete --all pvc &
 kubectl -n codacy delete --all pv  &

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -15,7 +15,6 @@ The cluster running Codacy must satisfy the following requirements:
 -   The orchestration platform managing the cluster must be one of:
     -   [Kubernetes](https://kubernetes.io/) **version 1.14.\*** or **1.15.\***
     -   [MicroK8s](https://microk8s.io/) **version 1.15**
--   Tiller, the server part of [Helm](https://v2.helm.sh/) **version 2.16**, must be installed in the cluster
 -   The [NGINX Ingress controller](https://github.com/kubernetes/ingress-nginx) must be installed and correctly set up in the cluster
 
 ### Cluster networking requirements

--- a/docs/troubleshoot/k8s-cheatsheet.md
+++ b/docs/troubleshoot/k8s-cheatsheet.md
@@ -21,7 +21,7 @@ helm upgrade --install codacy ./chart/codacy/ --namespace codacy --atomic --time
 ## Clean the namespace
 
 ```bash
-helm del --purge codacy
+helm -n codacy uninstall codacy
 kubectl -n codacy delete --all pod &
 kubectl -n codacy delete --all pvc &
 kubectl -n codacy delete --all pv  &


### PR DESCRIPTION
This brings back the changes reverted by <https://github.com/codacy/chart/pull/422> , which postponed until our stable version supports Helm v3.