### PR TITLE
bump: Update ci-do to the latest version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 references:
   default_doks_image: &default_doks_image
     docker:
-      - image: codacy/ci-do:1.6.5
+      - image: codacy/ci-do:1.6.6
     working_directory: ~/workdir/
 
   helm_values: &helm_values


### PR DESCRIPTION
Updates helm to 3.2.1 that has some bug fixes