### PR TITLE
fix: Disable Merge messages on changelogs.

### DIFF
--- a/.changelogs/gitchangelogtemplate.rc
+++ b/.changelogs/gitchangelogtemplate.rc
@@ -201,7 +201,7 @@ output_engine = mustache("##PATHMACRO##")
 ##
 ## This option tells git-log whether to include merge commits in the log.
 ## The default is to include them.
-include_merge = True
+include_merge = False
 
 
 ## ``log_encoding`` is a string identifier


### PR DESCRIPTION
This shall only get merged after the current ongoing release.