### PR TITLE
feature: Add release notes for 1.0.0.

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,0 +1,17 @@
+# Release notes
+
+## [1.0.0](https://github.com/codacy/chart/releases/tag/1.0.0)
+
+This is the initial release for Codacy Self-hosted running on Kubernetes.
+
+### Product enhancements
+
+-   Added support for Helm 3, maintaining backward compatibility with Helm 2. (CY-1606)
+-   Streamlined the configuration of Git providers and improved the onboarding flow that guides the user while performing the initial Codacy setup. (CY-468)
+
+### Bug fixes
+
+-   Fixed an issue that could cause pull requests to not be analyzed by improving the robustness of how Codacy fetches Git repositories. (CY-1542)
+-   Fixed an issue that caused Codacy to fail to display the information for the pull request tabs Hotspots and Diff. (CY-1690)
+-   Fixed an issue that prevented Codacy from analyzing repositories in synced organizations if the repositories had the state "OwnerNotCommiter". (CY-1611)
+-   Fixed an issue that prevented using the Codacy configuration file to exclude files from the coverage analysis. (CY-229)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -6,7 +6,6 @@ This is the initial release for Codacy Self-hosted running on Kubernetes.
 
 ### Product enhancements
 
--   Added support for Helm 3, maintaining backward compatibility with Helm 2. (CY-1606)
 -   Streamlined the configuration of Git providers and improved the onboarding flow that guides the user while performing the initial Codacy setup. (CY-468)
 
 ### Bug fixes

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,3 +63,4 @@ nav:
     - troubleshoot/troubleshoot.md
     - troubleshoot/logs-collect.md
     - troubleshoot/k8s-cheatsheet.md
+  - release-notes.md


### PR DESCRIPTION
We need to start having release notes for Codacy Self-hosted on Kubernetes.

Once the new documentation toolchain is ready (see https://github.com/codacy/docs) the release notes for both the Cloud and Self-hosted versions could be added on the docs repository. But until then, having the release notes in the Chart repository makes collaborating and reviewing the release notes easier than if they were hosted on Zendesk.