### PR TITLE
fix: Revert servicemonitor creation due to prometheus operator helm3 issues

### DIFF
--- a/.do/values.yaml
+++ b/.do/values.yaml
@@ -49,7 +49,7 @@ codacy-api:
     type: ClusterIP
   metrics:
     serviceMonitor:
-      enabled: true
+      enabled: false
     grafana_dashboards:
       enabled: true
 
@@ -98,7 +98,7 @@ engine:
   replicaCount: 1
   metrics:
     serviceMonitor:
-      enabled: true
+      enabled: false
 
 worker-manager:
   replicaCount: 1

--- a/docs/configuration/monitoring.md
+++ b/docs/configuration/monitoring.md
@@ -1,11 +1,15 @@
 # Monitoring
 
+<!---
+FIXME: Commented out to prevent issues while service monitors are not compatible with helm3
+
 Currently, we support two monitoring solutions:
 
 -   **[Crow](#setting-up-monitoring-using-crow):** A simple, lightweight, and built-in monitoring solution, that is enabled by default when you install Codacy.
 -   **[Prometheus + Grafana + Loki](#setting-up-monitoring-using-grafana-prometheus-and-loki):** A comprehensive third-party monitoring solution, recommended for more advanced usage.
 
 The sections below provide details on how to set up each monitoring solution.
+--->
 
 ## Setting up monitoring using Crow
 
@@ -41,6 +45,9 @@ We highly recommend that you define a custom password for Crow, if you haven't a
                  --values values-production.yaml \
                  # --values values-microk8s.yaml
     ```
+
+<!---
+FIXME: service dashboards are currently not compatible with helm3.
 
 ## Setting up monitoring using Grafana, Prometheus, and Loki
 
@@ -118,13 +125,13 @@ Now that you have Prometheus and Grafana installed you can enable `serviceMonito
     codacy-api:
       metrics:
         serviceMonitor:
-          enabled: false
+          enabled: true
         grafana_dashboards:
           enabled: true
     engine:
       metrics:
         serviceMonitor:
-          enabled: false
+          enabled: true
     worker-manager:
       grafana:
         grafana_dashboards:
@@ -141,3 +148,4 @@ Now that you have Prometheus and Grafana installed you can enable `serviceMonito
     helm upgrade (...options used to install Codacy...) \
                  --values values-monitoring.yaml --recreate-pods
     ```
+--->

--- a/docs/configuration/monitoring.md
+++ b/docs/configuration/monitoring.md
@@ -118,13 +118,13 @@ Now that you have Prometheus and Grafana installed you can enable `serviceMonito
     codacy-api:
       metrics:
         serviceMonitor:
-          enabled: true
+          enabled: false
         grafana_dashboards:
           enabled: true
     engine:
       metrics:
         serviceMonitor:
-          enabled: true
+          enabled: false
     worker-manager:
       grafana:
         grafana_dashboards:


### PR DESCRIPTION
With helm3 if service monitors are enabled deployment fails with the following error:

```
Error: UPGRADE FAILED: error validating "": error validating data: [ValidationError(ServiceMonitor.spec.selector): unknown field "app.kubernetes.io/instance" in com.coreos.monitoring.v1.ServiceMonitor.spec.selector, ValidationError(ServiceMonitor.spec.selector): unknown field "app.kubernetes.io/name" in com.coreos.monitoring.v1.ServiceMonitor.spec.selector]
  
```

I'm reverting this for now until we find a workaround and fix the components' servicemonitor templates.