### PR TITLE
fix: Remove deprecated flag --recreate-pods

### DIFF
--- a/docs/configuration/integrations/bitbucket-cloud.md
+++ b/docs/configuration/integrations/bitbucket-cloud.md
@@ -68,7 +68,6 @@ After creating the OAuth consumer on Bitbucket Cloud, you must configure it on C
 
     ```bash
     helm upgrade (...options used to install Codacy...) \
-                 --recreate-pods
                  --values values-production.yaml \
                  # --values values-microk8s.yaml
     ```

--- a/docs/configuration/integrations/bitbucket-server.md
+++ b/docs/configuration/integrations/bitbucket-server.md
@@ -72,7 +72,6 @@ After creating the Bitbucket Server application link, you must configure it on C
 
     ```bash
     helm upgrade (...options used to install Codacy...) \
-                 --recreate-pods
                  --values values-production.yaml \
                  # --values values-microk8s.yaml
     ```

--- a/docs/configuration/integrations/email.md
+++ b/docs/configuration/integrations/email.md
@@ -27,7 +27,6 @@ Follow the instructions below to set up Codacy to send emails using your SMTP se
 
     ```bash
     helm upgrade (...options used to install Codacy...) \
-                 --recreate-pods
                  --values values-production.yaml \
                  # --values values-microk8s.yaml
     ```

--- a/docs/configuration/integrations/github-cloud.md
+++ b/docs/configuration/integrations/github-cloud.md
@@ -29,7 +29,6 @@ Follow the instructions below to set up the Codacy integration with GitHub Cloud
 
     ```bash
     helm upgrade (...options used to install Codacy...) \
-                 --recreate-pods
                  --values values-production.yaml \
                  # --values values-microk8s.yaml
     ```

--- a/docs/configuration/integrations/github-enterprise.md
+++ b/docs/configuration/integrations/github-enterprise.md
@@ -34,7 +34,6 @@ Follow the instructions below to set up the Codacy integration with GitHub Enter
 
     ```bash
     helm upgrade (...options used to install Codacy...) \
-                 --recreate-pods
                  --values values-production.yaml \
                  # --values values-microk8s.yaml
     ```

--- a/docs/configuration/integrations/gitlab-cloud.md
+++ b/docs/configuration/integrations/gitlab-cloud.md
@@ -55,7 +55,6 @@ After creating the GitLab application, you must configure it on Codacy:
 
     ```bash
     helm upgrade (...options used to install Codacy...) \
-                 --recreate-pods
                  --values values-production.yaml \
                  # --values values-microk8s.yaml
     ```

--- a/docs/configuration/integrations/gitlab-enterprise.md
+++ b/docs/configuration/integrations/gitlab-enterprise.md
@@ -59,7 +59,6 @@ After creating the GitLab application, you must configure it on Codacy:
 
     ```bash
     helm upgrade (...options used to install Codacy...) \
-                 --recreate-pods
                  --values values-production.yaml \
                  # --values values-microk8s.yaml
     ```

--- a/docs/configuration/monitoring.md
+++ b/docs/configuration/monitoring.md
@@ -41,7 +41,6 @@ We highly recommend that you define a custom password for Crow, if you haven't a
 
     ```bash
     helm upgrade (...options used to install Codacy...) \
-                 --recreate-pods
                  --values values-production.yaml \
                  # --values values-microk8s.yaml
     ```
@@ -142,10 +141,10 @@ Now that you have Prometheus and Grafana installed you can enable `serviceMonito
           enabled: true
     ```
 
-2.  Apply this configuration by performing a Helm upgrade. To do so append `--values values-monitoring.yaml --recreate-pods` to the command [used to install Codacy](../index.md#helm-upgrade):
+2.  Apply this configuration by performing a Helm upgrade. To do so append `--values values-monitoring.yaml` to the command [used to install Codacy](../index.md#helm-upgrade):
 
     ```bash
     helm upgrade (...options used to install Codacy...) \
-                 --values values-monitoring.yaml --recreate-pods
+                 --values values-monitoring.yaml
     ```
 --->

--- a/docs/troubleshoot/troubleshoot.md
+++ b/docs/troubleshoot/troubleshoot.md
@@ -122,7 +122,6 @@ To solve this issue:
 
     ```bash
     helm upgrade (...options used to install Codacy...) \
-                 --recreate-pods
                  --values values-production.yaml \
                  # --values values-microk8s.yaml
     ```


### PR DESCRIPTION
The flag is deprecated in Helm 3.

See https://v3.helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
for more information. To maintain the functionality in Helm 3, it's required to make a change to the Helm template.

In this pull request I already removed the deprecated flag from the documentation, but the remaining changes are still pending.