### PR TITLE
Edit instructions on how to upgrade the Helm release

### DIFF
--- a/docs/maintenance/upgrade.md
+++ b/docs/maintenance/upgrade.md
@@ -8,7 +8,11 @@ To upgrade Codacy to the latest stable version:
     helm get values codacy \
                     --namespace codacy \
                     --output yaml > codacy.yaml
+
     ```
+
+    !!! note
+        If you installed Codacy on a Kubernetes namespace different from `codacy`, make sure that you adjust the namespace when executing the commands in this page.
 
 2.  Review the values stored in the file `codacy.yaml`, making any changes if necessary.
 

--- a/docs/maintenance/upgrade.md
+++ b/docs/maintenance/upgrade.md
@@ -1,26 +1,21 @@
 # Upgrading Codacy
 
-**NOTE:**
-You can retrieve your previous `--set` arguments cleanly, with
-`helm get values <release name>`. If you direct this into a file
-(`helm get values <release name> > codacy.yaml`), you can safely pass this
-file via `-f`, like `helm upgrade codacy codacy/codacy -f codacy.yaml`.
-This safely replaces the behavior of `--reuse-values`
+To upgrade Codacy to the latest stable version:
 
-The following are the steps to upgrade Codacy to a newer version:
-
-1. Extract your previous `--set` arguments with:
+1.  Store all your currently defined configuration values in a file:
 
     ```bash
-    helm get values codacy > codacy.yaml
+    helm get values codacy \
+                    --output yaml \
+                    --namespace codacy > codacy.yaml
     ```
 
-2. Decide on all the values you need to set.
+2.  Review the values stored in the file `codacy.yaml`, making any changes if necessary.
 
-3. Perform the upgrade, with all `--set` arguments extracted in step 2:
+3.  Perform the upgrade, setting the values stored in the file:
 
     ```bash
-    helm upgrade codacy codacy/codacy \
-      -f codacy.yaml \
-      --set ...
+    helm upgrade codacy codacy-stable/codacy \
+                 --namespace codacy \
+                 --values codacy.yaml
     ```

--- a/docs/maintenance/upgrade.md
+++ b/docs/maintenance/upgrade.md
@@ -6,13 +6,13 @@ To upgrade Codacy to the latest stable version:
 
     ```bash
     helm get values codacy \
-                    --output yaml \
-                    --namespace codacy > codacy.yaml
+                    --namespace codacy \
+                    --output yaml > codacy.yaml
     ```
 
 2.  Review the values stored in the file `codacy.yaml`, making any changes if necessary.
 
-3.  Perform the upgrade, setting the values stored in the file:
+3.  Perform the upgrade using the values stored in the file:
 
     ```bash
     helm upgrade codacy codacy-stable/codacy \


### PR DESCRIPTION
I'm reviewing the instructions on how to upgrade Codacy using Helm 3.

I (hopefully) fixed a couple of issues, namely:

* The fact that the namespace was not specified (I cannot tell for sure from the [Helm documentation](https://helm.sh/docs/helm/helm_get_values/#options-inherited-from-parent-commands) if this is required or not...)
* The output format for `helm get values` was not specified and the [default](https://helm.sh/docs/helm/helm_get_values/#options) would be `table`.

I need a validation that this is indeed the correct way of upgrading Codacy using Helm 3.