### PR TITLE
fix: Add port value for certain services

### DIFF
--- a/codacy/values.yaml
+++ b/codacy/values.yaml
@@ -15,6 +15,7 @@ global:
       url: "codacy-engine"
     listener:
       url: "codacy-listener"
+      port: 80
     activities:
       url: "codacy-activities"
     core:
@@ -23,6 +24,7 @@ global:
       url: "codacy-remote-provider-service"
     workerManager:
       url: "codacy-worker-manager"
+      port: 80
 
   github: {}
     # enabled: "false"


### PR DESCRIPTION
Services should really not be opinionated on what port they run on. That should
be configured when deploying on a specific environment. Since the service Crow
no longer assumes in its configurations on what ports some services are running,
we need to specify that here.

See https://bitbucket.org/qamine/crow/pull-requests/163/explicitly-set-sslmode-when-connecting-to