### PR TITLE
fix: Redirect docs root to latest version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -395,6 +395,7 @@ jobs:
           command: |
             sudo pip install -r requirements.pip
             mike deploy -u $(cat .version) latest -m "[ci skip] Updated documentation" -p
+            mike set-default latest
 
   get_changelogs:
     <<: *default_doks_image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -395,7 +395,7 @@ jobs:
           command: |
             sudo pip install -r requirements.pip
             mike deploy -u $(cat .version) latest -m "[ci skip] Updated documentation" -p
-            mike set-default latest
+            mike set-default latest -m "[ci skip] Updated default documentation version" -p
 
   get_changelogs:
     <<: *default_doks_image


### PR DESCRIPTION
Currently visiting the root of our docs show an older version of them. With this PR we are setting `latest` as the default docs, which then causes a redirection of the root to `latest` (see [here](https://github.com/jimporter/mike#setting-the-default-version) for more info).  I tested locally and it worked correctly.