### PR TITLE
feature: enable service monitors

### DIFF
--- a/.do/values.yaml
+++ b/.do/values.yaml
@@ -58,7 +58,7 @@ codacy-api:
     type: ClusterIP
   metrics:
     serviceMonitor:
-      enabled: false
+      enabled: true
     grafana_dashboards:
       enabled: true
 
@@ -77,6 +77,9 @@ activities:
 
 remote-provider-service:
   replicaCount: 1
+  metrics:
+    serviceMonitor:
+      enabled: true
 
 hotspots-api:
   replicaCount: 1
@@ -107,7 +110,7 @@ engine:
   replicaCount: 1
   metrics:
     serviceMonitor:
-      enabled: false
+      enabled: true
 
 worker-manager:
   replicaCount: 1

--- a/docs/configuration/monitoring.md
+++ b/docs/configuration/monitoring.md
@@ -1,15 +1,11 @@
 # Monitoring
 
-<!---
-FIXME: Commented out to prevent issues while service monitors are not compatible with helm3
-
 Currently, we support two monitoring solutions:
 
 -   **[Crow](#setting-up-monitoring-using-crow):** A simple, lightweight, and built-in monitoring solution, that is enabled by default when you install Codacy.
 -   **[Prometheus + Grafana + Loki](#setting-up-monitoring-using-grafana-prometheus-and-loki):** A comprehensive third-party monitoring solution, recommended for more advanced usage.
 
 The sections below provide details on how to set up each monitoring solution.
---->
 
 ## Setting up monitoring using Crow
 
@@ -44,9 +40,6 @@ We highly recommend that you define a custom password for Crow, if you haven't a
                  --values values-production.yaml \
                  # --values values-microk8s.yaml
     ```
-
-<!---
-FIXME: service dashboards are currently not compatible with helm3.
 
 ## Setting up monitoring using Grafana, Prometheus, and Loki
 
@@ -139,6 +132,10 @@ Now that you have Prometheus and Grafana installed you can enable `serviceMonito
       grafana:
         grafana_dashboards:
           enabled: true
+    remote-provider-service:
+      metrics:
+        serviceMonitor:
+          enabled: true
     ```
 
 2.  Apply this configuration by performing a Helm upgrade. To do so append `--values values-monitoring.yaml` to the command [used to install Codacy](../index.md#helm-upgrade):
@@ -147,4 +144,3 @@ Now that you have Prometheus and Grafana installed you can enable `serviceMonito
     helm upgrade (...options used to install Codacy...) \
                  --values values-monitoring.yaml
     ```
---->


### PR DESCRIPTION
This enables the service monitors in our dev environments, now that this has been upgraded in the components and won't cause validation errors when installed with helm3. This also uncomments the grafana+prometheus monitoring stack documentation because this becomes feasible and relevant again.