### PR TITLE
fix: Update version-select.js to correctly infer base URL

### DIFF
--- a/docs/js/version-select.js
+++ b/docs/js/version-select.js
@@ -1,18 +1,19 @@
-window.addEventListener("DOMContentLoaded", function () {
-  var VERSION = window.location.pathname.split("/")[1];
+window.addEventListener("DOMContentLoaded", function() {
+  // This is a bit hacky. Figure out the base URL from a known CSS file the
+  // template refers to...
+  var ex = new RegExp("/?css/version-select.css");
+  var sheet = document.querySelector('link[href$="version-select.css"]');
+
+  var ABS_BASE_URL = sheet.href.replace(ex, "");
+  var CURRENT_VERSION = ABS_BASE_URL.split("/").pop();
 
   function makeSelect(options, selected) {
     var select = document.createElement("select");
     select.classList.add("form-control");
-    select.classList.add("select-text");
 
-    options.forEach(function (i) {
-      var option = new Option(
-        i.text,
-        "/" + i.value,
-        undefined,
-        i.value === selected
-      );
+    options.forEach(function(i) {
+      var option = new Option(i.text, i.value, undefined,
+                              i.value === selected);
       select.add(option);
     });
 
@@ -20,40 +21,26 @@ window.addEventListener("DOMContentLoaded", function () {
   }
 
   var xhr = new XMLHttpRequest();
-  // Obtain JSON listing all available versions
-  xhr.open("GET", window.location.origin + "/versions.json");
-  xhr.onload = function () {
+  xhr.open("GET", ABS_BASE_URL + "/../versions.json");
+  xhr.onload = function() {
     var versions = JSON.parse(this.responseText);
 
-    // Identify which is the current version
-    var currentVersion = versions.find(function (i) {
-      return i.version === VERSION || i.aliases.includes(VERSION);
-    });
+    var realVersion = versions.find(function(i) {
+      return i.version === CURRENT_VERSION ||
+             i.aliases.includes(CURRENT_VERSION);
+    }).version;
 
-    var select = makeSelect(
-      versions.map(function (i) {
-        return { text: i.title, value: i.version };
-      }),
-      currentVersion
-    );
-
-    select.addEventListener("change", function (event) {
-      window.location.href = window.location.origin + this.value;
+    var select = makeSelect(versions.map(function(i) {
+      return {text: i.title, value: i.version};
+    }), realVersion);
+    select.addEventListener("change", function(event) {
+      window.location.href = ABS_BASE_URL + "/../" + this.value;
     });
 
     var container = document.createElement("div");
     container.id = "version-selector";
-    container.classList.add("md-nav__item");
-    container.classList.add("select");
+    container.className = "md-nav__item";
     container.appendChild(select);
-
-    var spanHighlight = document.createElement("span");
-    spanHighlight.classList.add("select-highlight");
-    container.appendChild(spanHighlight);
-
-    var spanBar = document.createElement("span");
-    spanBar.classList.add("select-bar");
-    container.appendChild(spanBar);
 
     var sidebar = document.querySelector(".md-nav--primary > .md-nav__list");
     sidebar.parentNode.insertBefore(container, sidebar);


### PR DESCRIPTION
This updates the script `version-select.js` with the original one provided by mike, but with a small change to use another known CSS file to infer the base URL of the documentation.

(See details here: https://github.com/jimporter/mike/pull/19)