### PR TITLE
Avoid resetting the default doc version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -400,7 +400,6 @@ jobs:
           command: |
             sudo pip install -r requirements.pip
             mike deploy -u $(cat .version) latest -m "[ci skip] Updated documentation" -p
-            mike set-default latest -m "[ci skip] Updated default documentation version" -p
 
   get_changelogs:
     <<: *default_doks_image


### PR DESCRIPTION
I'm deleting the following line that would "reset" the default docs version:

`mike set-default latest -m "[ci skip] Updated default documentation version" -p`

In practice, what this command does is (re)creating the `index.html` file at the root of the `gh-pages` branch with a small JavaScript to redirect to the `latest` path:

```javascript
window.location.replace("latest");
```

However, I had to update this JavaScript so it also takes into account anchor links and makes the appropriate redirections:

```javascript
(function () {
    var newPath = "latest/";
    var hash = window.location.hash.substring(1);
    if (hash) {
      window.location.replace(newPath + "#" + hash);
    } else {
      window.location.replace(newPath)
    }
})();
```

By removing the `mike set-default [...]` we ensure that my fix is not reverted on the next deploy of the documentation.

This is because we have some places in the product with links to specific anchor links, and those would be lost without this tweak. For example, in the screen below the link points to https://codacy.github.io/chart/#3-configuring-codacy, which is now correctly redirected to https://codacy.github.io/chart/latest/#3-configuring-codacy.

![image](https://user-images.githubusercontent.com/60105800/85417464-8a9c9d00-b567-11ea-90a6-12a11e5620ae.png)

(Thanks to @heliocodacy for spotting this!)