### PR TITLE
fix: set rabbitmq erlang cookie to prevent redeployment errors

### DIFF
--- a/codacy/values-production.yaml
+++ b/codacy/values-production.yaml
@@ -375,6 +375,7 @@ codacy-spa:
 
 rabbitmq-ha:
   replicaCount: 3
+  rabbitmqErlangCookie:  <--- erlang-cookie ---> # Generate one with `cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1`
   persistentVolume:
     enabled: true
     size: 8Gi

--- a/codacy/values.yaml
+++ b/codacy/values.yaml
@@ -426,6 +426,7 @@ fluentdoperator:
 ## These values are ignored if 'create: false' in the global variables
 
 rabbitmq-ha:
+  rabbitmqErlangCookie: "PLEASE_CHANGE_ME_TO_A_RANDOM_STR" # Generate one with `cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1`
   fullnameOverride: codacy-rabbitmq-ha
   rabbitmqUsername: "rabbitmq"
   rabbitmqPassword: "rabbitmq"


### PR DESCRIPTION
We should set this to a known value, to prevent errors on redeployment (cf. [here](https://github.com/helm/charts/tree/master/stable/rabbitmq-ha#upgrading-the-chart)). When merging this the new value for the erlangcookie will be different from the pre-existing one in our cluster so we'll need to delete the pvcs to ensure smooth deployment.