### PR TITLE
fix: disable Kamon in codacy-tools by default

### DIFF
--- a/codacy/values.yaml
+++ b/codacy/values.yaml
@@ -318,6 +318,9 @@ codacy-tools:
   fullnameOverride: codacy-tools
   config:
     environment: enterprise
+    metrics:
+      kamon:
+        enabled: "false"
   metrics:
     serviceMonitor:
       enabled: false


### PR DESCRIPTION
Kamon is somehow creating an issue while starting up codacy-tools, which makes it crash, and prevents the engine to start. I'm disabling it for now, until it is fixed, so that Codacy deploys cleanly.