### PR TITLE
doc: Add instructions on how to set and update the Codacy license

### DIFF
--- a/codacy/values-production.yaml
+++ b/codacy/values-production.yaml
@@ -172,6 +172,10 @@ codacy-api:
     requests:
       cpu: 500m
       memory: 500Mi
+## By default, Codacy includes a temporary license for a limited number of users.
+## Uncomment these annotations to enter a production license provided by a Codacy representative.
+#  config:
+#    license: <--- insert your Codacy license here --->
 
 portal:
   replicaCount: 2

--- a/docs/maintenance/license.md
+++ b/docs/maintenance/license.md
@@ -1,0 +1,24 @@
+# Updating your Codacy license
+
+Some changes to your Codacy plan require that you update your Codacy license with a new one provided by a Codacy representative:
+
+1.  Edit the value of `codacy-api.config.license` in the `values-production.yaml` file that you used to install Codacy:
+
+    ```yaml
+    codacy-api:
+      config:
+        license: <--- insert your Codacy license here --->
+    ```
+
+2.  Apply the new configuration by performing a Helm upgrade. To do so execute the command [used to install Codacy](../index.md#helm-upgrade):
+
+    !!! important
+        **If you are using MicroK8s** you must use the file `values-microk8s.yaml` together with the file `values-production.yaml`.
+
+        To do this, uncomment the last line before running the `helm upgrade` command below.
+
+    ```bash
+    helm upgrade (...options used to install Codacy...) \
+                 --values values-production.yaml \
+                 # --values values-microk8s.yaml
+    ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,7 @@ nav:
       - configuration/tls-ingress.md
       - configuration/monitoring.md
   - "Maintenance and operations":
+      - maintenance/license.md
       - maintenance/upgrade.md
       - maintenance/uninstall.md
       - maintenance/database.md


### PR DESCRIPTION
Currently we do not have instructions on how customers should set or update their production license.

I'm adding a placeholder on the `values-production.yaml` configuration file for setting the production license at installation time, as well as a short page explaining how the license can be updated at a later time.

**Note to self:** when this PR is merged I need to include a link to these instructions on the [page about enabling submodules](https://github.com/codacy/docs/pull/78).