### PR TITLE
doc: Fix malformed link to Let's Encrypt

### DIFF
--- a/docs/configuration/tls-ingress.md
+++ b/docs/configuration/tls-ingress.md
@@ -1,6 +1,6 @@
 # HTTPS using LetsEncrypt
 
-This documentation guides you on how to set up HTTPS for Codacy using (LetsEncript)[https://letsencrypt.org]
+This documentation guides you on how to set up HTTPS for Codacy using [Let's Encrypt](https://letsencrypt.org).
 
 For this, we will use:
 


### PR DESCRIPTION
Fixed incorrect Markdown syntax and typo in the name of the Let's Encrypt service.