### PR TITLE
doc: Rename site name from Chart to lowercase chart

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 # Project information
-site_name: Chart
+site_name: chart
 site_url: https://codacy.github.io/chart/
 
 # Configuration


### PR DESCRIPTION
This is to ensure that the path for the chart documentation on docs.codacy.com is lowercase (https://docs.codacy.com/chart/), making it consistent with all the other pages.

(This is in preparation to remove the old GitHub Pages site containing the chart documentation - https://codacy.atlassian.net/browse/DOCS-97)