### PR TITLE
doc: Correct Attribute Lists markup

### DIFF
--- a/docs/configuration/integrations/bitbucket-cloud.md
+++ b/docs/configuration/integrations/bitbucket-cloud.md
@@ -2,7 +2,7 @@
 
 Follow the instructions below to set up the Codacy integration with Bitbucket Cloud.
 
-## Create an OAuth consumer {id="create-oauth"}
+## Create an OAuth consumer {: id="create-oauth"}
 
 To integrate Codacy with Bitbucket Cloud, you must register an OAuth consumer for Codacy on Bitbucket.
 
@@ -42,7 +42,7 @@ You can create a consumer on any existing individual or team account. To create 
 
    ![Bitbucket consumer key and secret](images/bitbucket-consumer-key-and-secret.png)
 
-## Configure Bitbucket Cloud on Codacy {id="configure"}
+## Configure Bitbucket Cloud on Codacy {: id="configure"}
 
 After creating the OAuth consumer on Bitbucket Cloud, you must configure it on Codacy:
 

--- a/docs/configuration/integrations/gitlab-cloud.md
+++ b/docs/configuration/integrations/gitlab-cloud.md
@@ -2,7 +2,7 @@
 
 Follow the instructions below to set up the Codacy integration with GitLab Cloud.
 
-## Create a GitLab application {id="create-application"}
+## Create a GitLab application {: id="create-application"}
 
 To integrate Codacy with GitLab Cloud, you must create a GitLab application:
 
@@ -30,7 +30,7 @@ To integrate Codacy with GitLab Cloud, you must create a GitLab application:
 
 3.  Click **Save application** and take note of the generated Application Id and Secret.
 
-## Configure GitLab Cloud on Codacy {id="configure"}
+## Configure GitLab Cloud on Codacy {: id="configure"}
 
 After creating the GitLab application, you must configure it on Codacy:
 

--- a/docs/configuration/integrations/gitlab-enterprise.md
+++ b/docs/configuration/integrations/gitlab-enterprise.md
@@ -2,7 +2,7 @@
 
 Follow the instructions below to set up the Codacy integration with GitLab Enterprise:
 
-## Create a GitLab application {id="create-application"}
+## Create a GitLab application {: id="create-application"}
 
 To integrate Codacy with GitLab Enterprise, you must create a GitLab application:
 
@@ -31,7 +31,7 @@ To integrate Codacy with GitLab Enterprise, you must create a GitLab application
 
 3.  Click **Save application** and take note of the generated Application Id and Secret.
 
-## Configure GitLab Enterprise on Codacy {id="configure"}
+## Configure GitLab Enterprise on Codacy {: id="configure"}
 
 After creating the GitLab application, you must configure it on Codacy:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,7 @@ Install Codacy on an existing cluster using our Helm chart:
         --namespace codacy
     ```
 
-4.  Download the template file [`values-production.yaml`](./values-files/values-production.yaml){target="_blank"} and use a text editor of your choice to edit the value placeholders as described in the comments.
+4.  Download the template file [`values-production.yaml`](./values-files/values-production.yaml){: target="_blank"} and use a text editor of your choice to edit the value placeholders as described in the comments.
 
 5.  Create an address record on your DNS provider mapping the hostname you used in the previous step to the IP address of your Ingress controller.
 
@@ -71,7 +71,7 @@ Install Codacy on an existing cluster using our Helm chart:
 6.  <span id="helm-upgrade">Add Codacy's chart repository to your Helm client and install the Codacy chart using the file `values-production.yaml` created previously.</span>
 
     !!! important
-        **If you are using MicroK8s** you must use the file [`values-microk8s.yaml`](./values-files/values-microk8s.yaml) together with the file `values-production.yaml`.
+        **If you are using MicroK8s** you must use the file [`values-microk8s.yaml`](./values-files/values-microk8s.yaml){: target="_blank"} together with the file `values-production.yaml`.
 
     ```bash
     helm repo add codacy-stable https://charts.codacy.com/stable/

--- a/docs/troubleshoot/troubleshoot.md
+++ b/docs/troubleshoot/troubleshoot.md
@@ -12,7 +12,7 @@ If the information provided on this page is not enough to solve your issue, cont
 
 The following sections help you troubleshoot the integration of Codacy with your Git provider.
 
-### GitHub Cloud and GitHub Enterprise authentication {id="github"}
+### GitHub Cloud and GitHub Enterprise authentication {: id="github"}
 
 #### 404 error
 
@@ -32,7 +32,7 @@ If the error persists:
 1.  Take note of the parameter `client_id` in the URL of the GitHub error page (for example, `Iv1.0000000000000000`)
 2.  Check if the value of the parameter matches the value of the Client ID of your GitHub App
 
-### GitLab Cloud and GitLab Enterprise authentication {id="gitlab"}
+### GitLab Cloud and GitLab Enterprise authentication {: id="gitlab"}
 
 #### Invalid redirect URI
 
@@ -72,7 +72,7 @@ If the error persists:
 1.  Take note of the parameter `client_id` in the URL of the GitLab error page (for example, `cca35a2a1f9b9b516ac927d82947bd5149b0e57e922c9e5564ac092ea16a3ccd`)
 2.  Check if the value of the parameter matches the value of the Application ID of your GitLab application
 
-### Bitbucket Cloud authentication {id="bitbucket-cloud"}
+### Bitbucket Cloud authentication {: id="bitbucket-cloud"}
 
 #### Invalid client_id
 
@@ -96,7 +96,7 @@ If the error persists:
 
 The following sections help you troubleshoot the Codacy configuration.
 
-### Lost or changed database secrets {id="db-secrets"}
+### Lost or changed database secrets {: id="db-secrets"}
 
 When you open the Codacy UI, an error message states that the secret used to encrypt sensitive data on the database and the one in your configuration file are different.
 


### PR DESCRIPTION
This is to make the markup consistent to the one described in the documentation for the extension, as the previous markup was also working correctly:

https://python-markdown.github.io/extensions/attr_list/