### PR TITLE
doc: Edit troubleshooting instructions

### DIFF
--- a/docs/troubleshoot/troubleshoot.md
+++ b/docs/troubleshoot/troubleshoot.md
@@ -96,18 +96,24 @@ If the error persists:
 
 The following sections help you troubleshoot the Codacy configuration.
 
-### Rabbitmq access
+### Accessing the RabbitMQ dashboard
 
-We use `rabbitmq` for the internal message queue between our components.
+We use RabbitMQ for the internal message queue between our components.
 
-Should you need to access the `rabbitmq` dashboard, you need to do the following steps:
+If you need to access the RabbitMQ dashboard:
 
-1.  Create a `port-forward` from the rabbitmq pod to you local machine with:
+1.  Create a `port-forward` from the `rabbitmq` pod to your local machine, replacing `<namespace>` with the namespace in which Codacy was installed:
 
     ```bash
-    kubectl port-forward codacy-rabbitmq-ha-0 15672:15672 --namespace=$NAMESPACE
+    kubectl port-forward codacy-rabbitmq-ha-0 15672:15672 --namespace=<namespace>
     ```
 
-    Please note that you must provide the correct namespace.
+    !!! important
+        **If you are using MicroK8s** use `microk8s.kubectl` instead of `kubectl`.
 
-2.  Access the web ui through `localhost:15672`, logging in with the set `rabbitmq` credentials. See [README.md](https://github.com/codacy/chart/blob/master/README.md) for default values for these credentials.
+2.  Access the RabbitMQ dashboard on the address `localhost:15672`, and log in with the configured RabbitMQ credentials.
+
+    The default RabbitMQ credentials are the following:
+
+    -   **Username:** `rabbitmq-codacy`
+    -   **Password:** `rabbitmq-codacy`

--- a/docs/troubleshoot/troubleshoot.md
+++ b/docs/troubleshoot/troubleshoot.md
@@ -96,36 +96,6 @@ If the error persists:
 
 The following sections help you troubleshoot the Codacy configuration.
 
-### Lost or changed database secrets {id="db-secrets"}
-
-When you open the Codacy UI, an error message states that the secret used to encrypt sensitive data on the database and the one in your configuration file are different.
-
-To solve this issue:
-
-1.  Obtain the correct key from the Codacy logs by executing the following command, where `<namespace>` is the cluster namespace where Codacy is installed:
-
-    ```bash
-    bash <(curl -fsSL https://raw.githubusercontent.com/codacy/chart/master/docs/troubleshoot/extract-codacy-secrets.sh) \
-        -n <namespace>
-    ```
-
-    You can also download the script [extract-codacy-secrets.sh](extract-codacy-secrets.sh) to run it manually.
-
-2.  Copy the value of the key and update your `values-production.yaml` file with this value.
-
-3.  Apply the new configuration by performing a Helm upgrade. To do so execute the command [used to install Codacy](../index.md#helm-upgrade):
-
-    !!! important
-        **If you are using MicroK8s** you must use the file `values-microk8s.yaml` together with the file `values-production.yaml`.
-
-        To do this, uncomment the last line before running the `helm upgrade` command below.
-
-    ```bash
-    helm upgrade (...options used to install Codacy...) \
-                 --values values-production.yaml \
-                 # --values values-microk8s.yaml
-    ```
-
 ### Rabbitmq access
 
 We use `rabbitmq` for the internal message queue between our components.


### PR DESCRIPTION
Removes the spurious section **Lost or changed database secrets** (that had been removed in #458), and edits the instructions on how to access the RabbitMQ dashboard.