### PR TITLE
feature: Check if docs build successfully on every commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -392,6 +392,25 @@ jobs:
           command: cat .version
       - <<: *persist_to_workspace
 
+  build_docs:
+    docker:
+      - image: circleci/python:3.8
+    working_directory: ~/workdir/
+    steps:
+      - <<: *attach_workspace
+      - add_ssh_keys:
+          fingerprints:
+            - "df:83:d7:c7:d5:79:06:c2:3b:d1:fd:e2:a3:d1:12:c5"
+      - run:
+          name: ssh keyscan
+          command: |
+            ssh-keyscan github.com >> ~/.ssh/known_hosts
+      - run:
+          name: Build docs
+          command: |
+            sudo pip install -r requirements.pip
+            mkdocs build
+
   get_changelogs:
     <<: *default_doks_image
     steps:
@@ -467,6 +486,13 @@ workflows:
           <<: *helm_values
           requires:
             - helm_push_unstable
+
+  build_docs:
+    jobs:
+      - checkout
+      - build_docs:
+          requires:
+            - checkout
 
   deploy_chart_to_sandbox_cluster:
     jobs:

--- a/requirements.pip
+++ b/requirements.pip
@@ -1,2 +1,2 @@
 mkdocs==1.1.2
-mkdocs-material==5.2.2
+mkdocs-material==5.5.3


### PR DESCRIPTION
The idea is to do a quick build of the docs using `mkdocs build` just to check if something is broken. Otherwise, we will only know about issues when we build the docs on the [codacy/docs](https://github.com/codacy/docs) repository side.