### PR TITLE
Update supported Helm version

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -42,14 +42,7 @@ Install Codacy on an existing cluster using our Helm chart:
         !!! important
             **If you are using MicroK8s** you don't need to install kubectl because you will execute all `kubectl` commands as `microk8s.kubectl` commands instead. To simplify this, [check how to create an alias](infrastructure/microk8s-quickstart.md#notes-on-installing-codacy) for `kubectl`.
 
-    -   [Helm](https://helm.sh/docs/intro/install/) version 3.2
-
-        !!! warning
-            Helm 3.3 is not supported because there is a known incompatibility with the MinIO chart currently used by Codacy.
-            
-            More specifically, **Helm versions compiled with Go 1.14 or later are not supported**. You can check the Go version that was used to compile Helm with `helm version`.
-            
-            This will be fixed in a future version of Codacy Self-hosted.
+    -   [Helm](https://helm.sh/docs/intro/install/) version >= 3.2
 
 2.  Create a cluster namespace called `codacy` that will group all resources related to Codacy.
 


### PR DESCRIPTION
Drop incompatibility warning and support Helm versions >= 3.2.

The new version 1.6.0 should fix the incompatibility with MinIO and we can now support Helm 3.3 as well.

@joaocosta-codacy, since these changes apply to the new 1.6.0 release, we will need to cherry pick the changes to the branch `release-1.6.0`.