### PR TITLE
doc: Mention checking for breaking changes before upgrading Codacy

### DIFF
--- a/docs/maintenance/upgrade.md
+++ b/docs/maintenance/upgrade.md
@@ -2,7 +2,12 @@
 
 To upgrade Codacy to the latest stable version:
 
-1.  Store all your currently defined configuration values in a file:
+1.  Check the [release notes](/release-notes/) for all Codacy Self-hosted versions between your current version and the most recent version for breaking changes and follow the instructions provided carefully.
+
+    !!! warning
+        Failing to follow the steps to deal with breaking changes can cause the upgrade to fail or cause problems while Codacy is running.
+
+2.  Store all your currently defined configuration values in a file:
 
     ```bash
     helm get values codacy \
@@ -14,9 +19,9 @@ To upgrade Codacy to the latest stable version:
     !!! note
         If you installed Codacy on a Kubernetes namespace different from `codacy`, make sure that you adjust the namespace when executing the commands in this page.
 
-2.  Review the values stored in the file `codacy.yaml`, making any changes if necessary.
+3.  Review the values stored in the file `codacy.yaml`, making any changes if necessary.
 
-3.  Perform the upgrade using the values stored in the file:
+4.  Perform the upgrade using the values stored in the file:
 
     ```bash
     helm upgrade codacy codacy-stable/codacy \


### PR DESCRIPTION
Checking for breaking changes should be an explicit step before starting to upgrade Codacy.