### PR TITLE
feature: Full version of Codacy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-VERSION_NUMBER?=$(shell cat .version | grep -Eoh "^([0-9]+\.[0-9]+)" || echo "development")
+CODACY_VERSION_NUMBER?=$(shell cat .version || echo "development")
+DOCUMENTATION_VERSION_NUMBER?=$(shell cat .version | grep -Eoh "^([0-9]+\.[0-9]+)" || echo "development")
 
 .PHONY: setup_helm_repos
 setup_helm_repos:
@@ -14,7 +15,8 @@ setup_helm_repos:
 update_versions:
 	$(eval ENGINE_VERSION=$(shell grep "engine" -A 2 codacy/requirements.lock | grep version | cut -d : -f 2 | tr -d '[:blank:]'))
 	@echo ${ENGINE_VERSION}
-	ytool -f "./codacy/values.yaml" -s global.codacy.documentation.version "v${VERSION_NUMBER}" -e
+	ytool -f "./codacy/values.yaml" -s global.codacy.version "v${CODACY_VERSION_NUMBER}" -e
+	ytool -f "./codacy/values.yaml" -s global.codacy.documentation.version "v${DOCUMENTATION_VERSION_NUMBER}" -e
 	ytool -f "./codacy/values.yaml" -s global.workerManager.workers.config.imageVersion "${ENGINE_VERSION}" -e
 
 .PHONY: helm_dep_up

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ update_versions:
 	$(eval ENGINE_VERSION=$(shell grep "engine" -A 2 codacy/requirements.lock | grep version | cut -d : -f 2 | tr -d '[:blank:]'))
 	@echo ${ENGINE_VERSION}
 	ytool -f "./codacy/values.yaml" -s global.codacy.version "v${CODACY_VERSION_NUMBER}" -e
-	ytool -f "./codacy/values.yaml" -s global.codacy.documentation.version "v${DOCUMENTATION_VERSION_NUMBER}" -e
+	ytool -f "./codacy/values.yaml" -s global.codacy.documentation.installation.version "v${DOCUMENTATION_VERSION_NUMBER}" -e
 	ytool -f "./codacy/values.yaml" -s global.workerManager.workers.config.imageVersion "${ENGINE_VERSION}" -e
 
 .PHONY: helm_dep_up

--- a/codacy/values.yaml
+++ b/codacy/values.yaml
@@ -31,6 +31,7 @@ global:
       port: 80
     # Trial license. Valid for 4 users until the end of 2020
     license: "RAjlCYb/DxsAME0TjIn55neFSYOt0yxxnXBh4nKe/hbz4mjr0dDs3TLOehzQ3QyaLfONRva7T2iSkA57bMdpI/ZwAOUQtjO5XiU1KDaSUXCFZwDu1mBJMlMONCVOV3AuB6y56tsL0CZXnBqZD3R9dShTVXiSYDt/+2dhlVqGb70="
+    version: development
     documentation:
       version: development
 

--- a/codacy/values.yaml
+++ b/codacy/values.yaml
@@ -31,7 +31,8 @@ global:
       port: 80
     # Trial license. Valid for 4 users until the end of 2020
     license: "RAjlCYb/DxsAME0TjIn55neFSYOt0yxxnXBh4nKe/hbz4mjr0dDs3TLOehzQ3QyaLfONRva7T2iSkA57bMdpI/ZwAOUQtjO5XiU1KDaSUXCFZwDu1mBJMlMONCVOV3AuB6y56tsL0CZXnBqZD3R9dShTVXiSYDt/+2dhlVqGb70="
-    version: development
+    installation:
+      version: development
     documentation:
       version: development
 


### PR DESCRIPTION
This is the companion of:
https://bitbucket.org/qamine/codacy-website/pull-requests/3837/feature-add-an-api-endpoint-to-return-the

to inject the full version of the codacy installation.