### PR TITLE
doc: Fix chart version when running helm upgrade

### DIFF
--- a/docs/configuration/integrations/bitbucket-cloud.md
+++ b/docs/configuration/integrations/bitbucket-cloud.md
@@ -68,6 +68,7 @@ After creating the OAuth consumer on Bitbucket Cloud, you must configure it on C
 
     ```bash
     helm upgrade (...options used to install Codacy...) \
+                 --version {{ version }} \
                  --values values-production.yaml \
                  # --values values-microk8s.yaml
     ```

--- a/docs/configuration/integrations/bitbucket-server.md
+++ b/docs/configuration/integrations/bitbucket-server.md
@@ -72,6 +72,7 @@ After creating the Bitbucket Server application link, you must configure it on C
 
     ```bash
     helm upgrade (...options used to install Codacy...) \
+                 --version {{ version }} \
                  --values values-production.yaml \
                  # --values values-microk8s.yaml
     ```

--- a/docs/configuration/integrations/email.md
+++ b/docs/configuration/integrations/email.md
@@ -27,6 +27,7 @@ Follow the instructions below to set up Codacy to send emails using your SMTP se
 
     ```bash
     helm upgrade (...options used to install Codacy...) \
+                 --version {{ version }} \
                  --values values-production.yaml \
                  # --values values-microk8s.yaml
     ```

--- a/docs/configuration/integrations/github-cloud.md
+++ b/docs/configuration/integrations/github-cloud.md
@@ -29,6 +29,7 @@ Follow the instructions below to set up the Codacy integration with GitHub Cloud
 
     ```bash
     helm upgrade (...options used to install Codacy...) \
+                 --version {{ version }} \
                  --values values-production.yaml \
                  # --values values-microk8s.yaml
     ```

--- a/docs/configuration/integrations/github-enterprise.md
+++ b/docs/configuration/integrations/github-enterprise.md
@@ -34,6 +34,7 @@ Follow the instructions below to set up the Codacy integration with GitHub Enter
 
     ```bash
     helm upgrade (...options used to install Codacy...) \
+                 --version {{ version }} \
                  --values values-production.yaml \
                  # --values values-microk8s.yaml
     ```

--- a/docs/configuration/integrations/gitlab-cloud.md
+++ b/docs/configuration/integrations/gitlab-cloud.md
@@ -55,6 +55,7 @@ After creating the GitLab application, you must configure it on Codacy:
 
     ```bash
     helm upgrade (...options used to install Codacy...) \
+                 --version {{ version }} \
                  --values values-production.yaml \
                  # --values values-microk8s.yaml
     ```

--- a/docs/configuration/integrations/gitlab-enterprise.md
+++ b/docs/configuration/integrations/gitlab-enterprise.md
@@ -59,6 +59,7 @@ After creating the GitLab application, you must configure it on Codacy:
 
     ```bash
     helm upgrade (...options used to install Codacy...) \
+                 --version {{ version }} \
                  --values values-production.yaml \
                  # --values values-microk8s.yaml
     ```

--- a/docs/configuration/monitoring.md
+++ b/docs/configuration/monitoring.md
@@ -38,6 +38,7 @@ We highly recommend that you define a custom password for Crow, if you haven't a
 
     ```bash
     helm upgrade (...options used to install Codacy...) \
+                 --version {{ version }} \
                  --values values-production.yaml \
                  # --values values-microk8s.yaml
     ```
@@ -132,5 +133,6 @@ Now that you have Prometheus and Grafana installed you can enable `serviceMonito
 
     ```bash
     helm upgrade (...options used to install Codacy...) \
+                 --version {{ version }} \
                  --values values-monitoring.yaml
     ```

--- a/docs/configuration/tls-ingress.md
+++ b/docs/configuration/tls-ingress.md
@@ -56,5 +56,6 @@ Set up Ingress to use TLS:
 2.  Apply the new configuration by performing a Helm upgrade, using the same options you have previously used to install Codacy.
 
     ```bash
-    helm upgrade (...options used to install Codacy...)
+    helm upgrade (...options used to install Codacy...) \
+                 --version {{ version }} 
     ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,6 +78,7 @@ Install Codacy on an existing cluster using our Helm chart:
     helm repo update
     helm upgrade --install codacy codacy-stable/codacy \
                  --namespace codacy \
+                 --version 2.0.0 \
                  --values values-production.yaml
                  # --values values-microk8s.yaml
     ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,7 +78,7 @@ Install Codacy on an existing cluster using our Helm chart:
     helm repo update
     helm upgrade --install codacy codacy-stable/codacy \
                  --namespace codacy \
-                 --version 2.0.0 \
+                 --version {{ version }} \
                  --values values-production.yaml
                  # --values values-microk8s.yaml
     ```

--- a/docs/maintenance/license.md
+++ b/docs/maintenance/license.md
@@ -19,6 +19,7 @@ Some changes to your Codacy plan require that you update your Codacy license wit
 
     ```bash
     helm upgrade (...options used to install Codacy...) \
+                 --version {{ version }} \
                  --values values-production.yaml \
                  # --values values-microk8s.yaml
     ```

--- a/docs/troubleshoot/k8s-cheatsheet.md
+++ b/docs/troubleshoot/k8s-cheatsheet.md
@@ -10,7 +10,7 @@ helm dep build ./chart/codacy
 helm upgrade --install codacy ./chart/codacy/ --namespace codacy --atomic --timeout=300 --values ./<YOUR-VALUES-FILE>
 ```
 
-### Update
+### Upgrade
 
 ```bash
 (cd chart; sudo git fetch --all --prune --tags; sudo git reset --hard origin/<YOUR-BRANCH>;)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,9 @@ theme:
         primary: 'indigo'
         accent: 'indigo'
 
+extra:
+  version: 2.0.0
+
 extra_css:
   - 'assets/stylesheets/extra.css'
 extra_javascript:
@@ -23,6 +26,7 @@ copyright: '© <a href="https://www.codacy.com/">Codacy</a>'
 # Plugins and extensions
 plugins:
   - search
+  - markdownextradata
 
 markdown_extensions:
   - admonition

--- a/requirements.pip
+++ b/requirements.pip
@@ -1,2 +1,3 @@
 mkdocs==1.1.2
 mkdocs-material==5.5.3
+mkdocs-markdownextradata-plugin==0.1.7


### PR DESCRIPTION
I'm renaming the branch originally created for #553 because the single quotes [caused issues on the CI/CD workflows](https://app.circleci.com/pipelines/github/codacy/chart/4134/workflows/0a34214f-864b-4073-92f5-8ce9c96d6e9a/jobs/18486).