### PR TITLE
doc: Edit introduction to Amazon EKS diagram

### DIFF
--- a/docs/infrastructure/eks-quickstart.md
+++ b/docs/infrastructure/eks-quickstart.md
@@ -2,10 +2,9 @@
 
 Follow the instructions below to set up an Amazon EKS cluster from scratch, including all the necessary underlying infrastructure, using Terraform.
 
-![codacy eks quicksart](images/codacy-chart-eks-quickstart.jpg)
+The following diagram is a non-exhaustive overview of what you can expect to have deployed in your AWS account by using this quickstart guide.
 
-The image above is a non-exhaustive overview of what you can expect to have
-deployed in your AWS account by using this quickstart.
+![Codacy Amazon EKS quickstart](images/codacy-chart-eks-quickstart.jpg){: width="1024"}
 
 ## 1. Prepare your environment
 


### PR DESCRIPTION
Small edits:
* Move the introduction of the diagram before the image.
* Limit the size of the image to 1024 pixels wide
* Fix typo in image alternative text