### PR TITLE
bump: codacy-orbs to include fix for removing base users CY-1441

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/base@4.5.4
+  codacy: codacy/base@4.5.5
   slack: circleci/slack@3.4.2
 
 references:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/base@4.5.1
+  codacy: codacy/base@4.5.4
   slack: circleci/slack@3.4.2
 
 references:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/base@4.5.6
+  codacy: codacy/base@4.5.7
   slack: circleci/slack@3.4.2
 
 references:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/base@4.5.5
+  codacy: codacy/base@4.5.6
   slack: circleci/slack@3.4.2
 
 references:


### PR DESCRIPTION
This will bring the latest changes to the orb in https://github.com/codacy/codacy-orbs/pull/118

Microk8s tests should run successfully regardless of having the old base users