### PR TITLE
fix: Delete additional fields from fluentd output

### DIFF
--- a/codacy/templates/fluentd/fluentd-conf.yaml
+++ b/codacy/templates/fluentd/fluentd-conf.yaml
@@ -17,7 +17,7 @@ data:
     <filter **>
       @type record_modifier
       <record>
-        for_remove ${record["kubernetes"].delete("namespace_name"); record["kubernetes"].delete("pod_id"); record["kubernetes"].delete("namespace_labels"); record["kubernetes"].delete("container_info"); record["kubernetes"].delete("labels"); record.delete("container_info"); record.delete("docker")}
+        for_remove ${record["kubernetes"].delete("namespace_name"); record["kubernetes"].delete("pod_id"); record["kubernetes"].delete("namespace_labels"); record["kubernetes"].delete("container_info"); record["kubernetes"].delete("labels"); record["kubernetes"].delete("container_name"); record["kubernetes"].delete("pod_name"); record["kubernetes"].delete("container_image_id"); record["kubernetes"].delete("host"); record.delete("container_info"); record.delete("docker")}
       </record>
       # This removes the fields defined in `for_remove` from the logs
       remove_keys for_remove


### PR DESCRIPTION
Deleted:
* kubernetes.host
* kubernetes.container_image_id
* kubernetes.pod_name
* kubernetes.container_name