### PR TITLE
Add missing redirect URI when configuring GitLab Enterprise

### DIFF
--- a/docs/configuration/integrations/gitlab-enterprise.md
+++ b/docs/configuration/integrations/gitlab-enterprise.md
@@ -16,6 +16,7 @@ To integrate Codacy with GitLab Enterprise, you must create a GitLab application
 
         ```text
         https://codacy.example.com/login/GitLabEnterprise
+        https://codacy.example.com/add/addProvider/GitLabEnterprise
         https://codacy.example.com/add/addService/GitLabEnterprise
         https://codacy.example.com/add/addPermissions/GitLabEnterprise
         ```


### PR DESCRIPTION
The URI appeared correctly in the example screenshot but not on the instruction step.

Thanks to @heliocodacy for reporting this. :+1: 