### PR TITLE
Add missing redirect URI when configuring GitLab Cloud

### DIFF
--- a/docs/configuration/integrations/gitlab-cloud.md
+++ b/docs/configuration/integrations/gitlab-cloud.md
@@ -16,6 +16,7 @@ To integrate Codacy with GitLab Cloud, you must create a GitLab application:
 
         ```text
         https://codacy.example.com/login/GitLab
+        https://codacy.example.com/add/addProvider/GitLab
         https://codacy.example.com/add/addService/GitLab
         https://codacy.example.com/add/addPermissions/GitLab
         ```


### PR DESCRIPTION
The URI appeared correctly in the example screenshot but not on the instruction step.

This is the same issue that was fixed on #581, but for GitLab Cloud (we only noticed the issue after merging the previous pull request).