### PR TITLE
doc: Add step to link GitHub release with release notes page

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -218,6 +218,12 @@ Then, the Release Manager releases and announces the new version:
          git push --tag origin self-hosted-x.x.x
          ```
 
+    5.  Add a link to the release notes page to the description of the new release on GitHub:
+
+        ```markdown
+        Release notes: <release notes URL>
+        ```
+
 -   [ ] 3.  Inform all stakeholders that the release is finished
 
 The final version will be `x.x.x`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -218,7 +218,9 @@ Then, the Release Manager releases and announces the new version:
          git push --tag origin self-hosted-x.x.x
          ```
 
-    5.  Add a link to the release notes page to the description of the new release on GitHub. Substitute `x.x.x` with the version being released:
+    5.  Add a link to the release notes page to the [description of the new release](https://github.com/codacy/chart/releases) on GitHub.
+    
+        Substitute `x.x.x` in the URL with the version being released:
 
         ```markdown
         Release notes: https://docs.codacy.com/release-notes/self-hosted/self-hosted-vx.x.x/

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -218,10 +218,10 @@ Then, the Release Manager releases and announces the new version:
          git push --tag origin self-hosted-x.x.x
          ```
 
-    5.  Add a link to the release notes page to the description of the new release on GitHub:
+    5.  Add a link to the release notes page to the description of the new release on GitHub. Substitute `x.x.x` with the version being released:
 
         ```markdown
-        Release notes: <release notes URL>
+        Release notes: https://docs.codacy.com/release-notes/self-hosted/self-hosted-vx.x.x/
         ```
 
 -   [ ] 3.  Inform all stakeholders that the release is finished


### PR DESCRIPTION
As a way to give more visibility to the release notes for each new chart version, it's a good idea to add a link to the public release notes page on each new version. For example: https://github.com/codacy/chart/releases/tag/2.1.1

I'm adding a step to the release process to manually add a link to the release notes page. But perhaps this step could be automated, as the URL of the release notes can be easily built by taking the new version number into account.