### PR TITLE
doc: Disable "Expire user authorization tokens" while creating GitHub Apps

### DIFF
--- a/docs/configuration/integrations/github-app-create.md
+++ b/docs/configuration/integrations/github-app-create.md
@@ -15,6 +15,7 @@ To create the GitHub App:
     | GitHub App name                         | Codacy                                                  |
     | Homepage URL                            | `https://codacy.example.com`                            |
     | User authorization callback URL         | `https://codacy.example.com`                            |
+    | Expire user authorization tokens        | Disabled                                                |
     | Webhook URL                             | For GitHub Cloud:<br/>`https://codacy.example.com/2.0/events/gh/organization`<br/><br/>For GitHub Enterprise:<br/>`https://codacy.example.com/2.0/events/ghe/organization` |
     | **Repository permissions**              |                                                         |
     | Administration                          | Read & write                                            |


### PR DESCRIPTION
Fixes https://github.com/codacy/docs/issues/201.

When configuring a new GitHub App, we now ask the user to explicitly disable the setting **Expire user authorization tokens**.