### PR TITLE
fix: Remove TLS setup annotations from values-production.yaml

### DIFF
--- a/codacy/values-production.yaml
+++ b/codacy/values-production.yaml
@@ -193,18 +193,6 @@ codacy-ingress:
       kubernetes.io/ingress.class: "nginx"
       nginx.ingress.kubernetes.io/use-regex: "true"
 
-## Uncomment these annotations and the `tls:` block to use TLS
-## For guidance on how to set up TLS please refer to the documentation on https://codacy.github.io/chart
-#
-#      kubernetes.io/tls-acme: "true"
-#      cert-manager.io/issuer: letsencrypt-codacy
-#    tls:
-#      secretName: codacy-tls
-#      hosts:
-#        - host: <--- codacy.example.com ---> # Codacy application DNS hostname
-#          paths:
-#            - /
-
 codacy-api:
   replicaCount: 2
   resources:


### PR DESCRIPTION
We removed the TLS setup documentation on https://github.com/codacy/chart/pull/560, but the `values-production.yaml` file still referenced the documentation for more information on how to perform the configuration.