### PR TITLE
feature: Added job to automate release creation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,17 +278,6 @@ references:
             export EXECUTION_TIME=`date +%F_%Hh%M-%Z`
             sh /opt/tests/qa-automation-test-runner/build/run_tests.sh
 
-  append_releasenotes_link: &append_releasenotes_link
-    steps:
-      - <<: *attach_workspace
-      - deploy:
-          name: Append release notes link to releasenotes.md
-          command: |
-            version=$(cat .version | cut -d - -f1)
-
-      - <<: *persist_to_workspace
-
-
 ############
 #  JOBS
 ############
@@ -438,7 +427,7 @@ jobs:
             version=$(cat .version)
             contents="Release notes: https://docs.codacy.com/release-notes/self-hosted/self-hosted-v$version/"
 
-            curl -X POST -H "Authorization: token $CIRCLECI_GITHUB_TOKEN" https://api.github.com/repos/codacy/chart/releases \
+            curl -X POST -H "Authorization: token $CIRCLE_CI_GITHUB_TOKEN" https://api.github.com/repos/codacy/chart/releases \
             -d '{
               "tag_name": "$version",
               "target_commitish": "master",
@@ -701,11 +690,17 @@ workflows:
           force: true
           requires:
             - promote_chart_to_stable
-      - publish_release_notes:
+      - manual_release_notes_hold:
+          type: approval
           context: CodacyDO
           requires:
             - tag_version_latest
+      - publish_release_notes:
+          context: CodacyDO
+          requires:
+            - manual_release_notes_hold
       - slack_notify_release:
           context: CodacyDO
           requires:
             - tag_version_latest
+            - publish_release_notes

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,6 +278,17 @@ references:
             export EXECUTION_TIME=`date +%F_%Hh%M-%Z`
             sh /opt/tests/qa-automation-test-runner/build/run_tests.sh
 
+  append_releasenotes_link: &append_releasenotes_link
+    steps:
+      - <<: *attach_workspace
+      - deploy:
+          name: Append release notes link to releasenotes.md
+          command: |
+            version=$(cat .version | cut -d - -f1)
+
+      - <<: *persist_to_workspace
+
+
 ############
 #  JOBS
 ############
@@ -416,6 +427,26 @@ jobs:
           title: $(cat .version)
           message: |
             Version $(cat .version) of the Codacy chart has been released!
+
+  publish_release_notes: &publish_release_notes
+    <<: *default_doks_image
+    steps:
+      - <<: *attach_workspace
+      - deploy:
+          name: Publish release notes link on github
+          command: |
+            version=$(cat .version)
+            contents="Release notes: https://docs.codacy.com/release-notes/self-hosted/self-hosted-v$version/"
+
+            curl -X POST -H "Authorization: token $CIRCLECI_GITHUB_TOKEN" https://api.github.com/repos/codacy/chart/releases \
+            -d '{
+              "tag_name": "$version",
+              "target_commitish": "master",
+              "name": "$version",
+              "body": "$contents",
+              "draft": false,
+              "prerelease": false
+            }'\
 
 ############
 #  WORKFLOWS
@@ -670,6 +701,10 @@ workflows:
           force: true
           requires:
             - promote_chart_to_stable
+      - publish_release_notes:
+          context: CodacyDO
+          requires:
+            - tag_version_latest
       - slack_notify_release:
           context: CodacyDO
           requires:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -218,14 +218,6 @@ Then, the Release Manager releases and announces the new version:
          git push --tag origin self-hosted-x.x.x
          ```
 
-    5.  Add a link to the release notes page to the [description of the new release](https://github.com/codacy/chart/releases) on GitHub.
-    
-        Substitute `x.x.x` in the URL with the version being released:
-
-        ```markdown
-        Release notes: https://docs.codacy.com/release-notes/self-hosted/self-hosted-vx.x.x/
-        ```
-
 -   [ ] 3.  Inform all stakeholders that the release is finished
 
 The final version will be `x.x.x`.


### PR DESCRIPTION
This will also post the release notes link in the body of the release.

All that is left to do is provision the CIRCLECI_GITHUB_TOKEN with a relevant github user from our org for this to work.