### PR TITLE
fix: Use correct version for documentation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,7 +283,7 @@ references:
 ############
 
 jobs:
-  checkout:
+  checkout_and_version_from_git_tag:
     docker:
       - image: codacy/ci-base:1.0.1
     working_directory: ~/workdir/
@@ -292,7 +292,7 @@ jobs:
       - run:
           name: setup version from git tag
           command: |
-            git tag --sort creatordate | grep -E "^([0-9]+\.[0-9]+\.[0-9]+)-RC.*" | tail -n -1 > .version
+            make setup_version_from_git_tag
             echo $(cat .version)
       - <<: *persist_to_workspace
 
@@ -476,10 +476,10 @@ workflows:
 
   build_docs:
     jobs:
-      - checkout
+      - checkout_and_version_from_git_tag
       - build_docs:
           requires:
-            - checkout
+            - checkout_and_version_from_git_tag
 
   deploy_chart_to_sandbox_cluster:
     jobs:
@@ -528,7 +528,7 @@ workflows:
 
   release_pipeline:
     jobs:
-      - checkout:
+      - checkout_and_version_from_git_tag:
           filters:
             branches:
               only:
@@ -537,7 +537,7 @@ workflows:
           name: helm_lint
           cmd: helm lint --set-string global.akka.sessionSecret="" codacy/
           requires:
-            - checkout
+            - checkout_and_version_from_git_tag
       - helm_push_incubator:
           context: CodacyDO
           requires:

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ releasenotes.md
 missingreleasenotes.md
 changelog.md
 codacy/requirements_old.lock
+.version

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 CODACY_VERSION_NUMBER?=$(shell sed -e 's/.*/v&/g' .version || echo "development")
 DOCUMENTATION_VERSION_NUMBER?=$(shell sed -e 's/.*/v&/g' .version | grep -Eoh "^v([0-9]+\.[0-9]+)" || echo "development")
 
+.PHONY: setup_version_from_git_tag
+setup_version_from_git_tag:
+	git tag --sort creatordate | grep -E "^([0-9]+\.[0-9]+\.[0-9]+)-RC.*" | tail -n -1 > .version
+
 .PHONY: setup_helm_repos
 setup_helm_repos:
 	helm repo add bitnami https://charts.bitnami.com/bitnami
@@ -28,6 +32,9 @@ helm_dep_up:
 
 .PHONY: update_dependencies
 update_dependencies: setup_helm_repos helm_dep_up update_versions
+
+.PHONY: prepare_release
+prepare_release: setup_version_from_git_tag update_dependencies
 
 .PHONY: get_release_notes
 get_release_notes: setup_helm_repos helm_dep_up

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -65,10 +65,10 @@ The Release Manager must create a release candidate branch:
     Run the following command:
 
     ```bash
-    make update_dependencies
+    make prepare_release
     ```
 
-    This will update the `requirements.lock` with the latest versions and freeze the `global.workers.config.imageVersion` version on `./codacy/values.yaml`.
+    This will update the `requirements.lock` with the latest versions and freeze multiple version values on `./codacy/values.yaml`.
 
 -   [ ] 5.  Commit the updated `requirements.lock` and `./codacy/values.yaml` to the branch
 


### PR DESCRIPTION
Currently we are setting the version for the documentation. Since the `.version` file is only created during the circleci worflow.

This makes it so that we generate the version locally when running the `make prepare_release` command