### PR TITLE
doc: Remove spurious and empty file releasenotes.md

### DIFF
--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -1,3 +1,0 @@
-# Release notes
-
-This is a release notes template file.


### PR DESCRIPTION
Since this file is not referenced in `mkdocs.yml`, MkDocs outputs a warning when generating the documentation.