### PR TITLE
doc: Edit page title to mention Codacy Self-hosted

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
-# Installing Codacy on Kubernetes
+# Installing Codacy Self-hosted
 
-This documentation guides you on how to install Codacy on Kubernetes or MicroK8s.
+This documentation guides you on how to install Codacy Self-hosted on Kubernetes or MicroK8s.
 
 To install Codacy you must complete these main steps:
 


### PR DESCRIPTION
The installation documentation did not explicitly mention that it applies to Codacy Self-hosted. Although this is obvious to us, it may not be obvious for inexperienced users.