### PR TITLE
doc: Remove command that wrongly deletes all PVs in the cluster

### DIFF
--- a/docs/maintenance/uninstall.md
+++ b/docs/maintenance/uninstall.md
@@ -7,16 +7,13 @@ To do so run:
 helm -n codacy uninstall codacy
 kubectl -n codacy delete --all pod &
 kubectl -n codacy delete --all pvc &
-kubectl -n codacy delete --all pv  &
 kubectl -n codacy delete --all job &
 sleep 5
 kubectl -n codacy patch pvc -p '{"metadata":{"finalizers":null}}' $(kubectl -n codacy get pvc -o jsonpath='{.items[*].metadata.name}')
-kubectl -n codacy patch pv -p '{"metadata":{"finalizers":null}}' $(kubectl -n codacy get pv -o jsonpath='{.items[*].metadata.name}')
 sleep 5
 kubectl -n codacy delete pod $(kubectl -n codacy get pod -o jsonpath='{.items[*].metadata.name}') --force --grace-period=0
 kubectl -n codacy get pod &
 kubectl -n codacy get pvc &
-kubectl -n codacy get pv  &
 kubectl -n codacy get job &
 ```
 

--- a/docs/troubleshoot/k8s-cheatsheet.md
+++ b/docs/troubleshoot/k8s-cheatsheet.md
@@ -67,31 +67,6 @@ Rollback to a specific revision:
 helm -n codacy rollback codacy <REVISION>
 ```
 
-## Clean the namespace
-
-```bash
-helm -n codacy uninstall codacy
-kubectl -n codacy delete --all pod &
-kubectl -n codacy delete --all pvc &
-kubectl -n codacy delete --all pv  &
-kubectl -n codacy delete --all job &
-sleep 5
-kubectl -n codacy patch pvc -p '{"metadata":{"finalizers":null}}' $(kubectl -n codacy get pvc -o jsonpath='{.items[*].metadata.name}')
-kubectl -n codacy patch pv -p '{"metadata":{"finalizers":null}}' $(kubectl -n codacy get pv -o jsonpath='{.items[*].metadata.name}')
-sleep 5
-kubectl -n codacy delete pod $(kubectl -n codacy get pod -o jsonpath='{.items[*].metadata.name}') --force --grace-period=0
-kubectl -n codacy get pod &
-kubectl -n codacy get pvc &
-kubectl -n codacy get pv  &
-kubectl -n codacy get job &
-```
-
-### Check uninstall was successful
-
-```bash
-ps aux | grep -i kubectl
-```
-
 ## Edit configmap
 
 ```bash


### PR DESCRIPTION
The offending command removes all PVs in the cluster since PVs are not bound to a specific namespace.

More information on Slack:

https://codacy.slack.com/archives/C8X9SS1H7/p1602489596000800