### PR TITLE
fix: fluentd namespace resolution

### DIFF
--- a/codacy/templates/fluentd/fluentd-conf.yaml
+++ b/codacy/templates/fluentd/fluentd-conf.yaml
@@ -14,7 +14,7 @@ data:
     </match>
 
     # Remove unneeded fields from the logs
-    <filter kubernetes.var.log.containers.**{{ .Release.Namespace }}**>
+    <filter **>
       @type record_modifier
       <record>
         for_remove ${record["kubernetes"].delete("namespace_name"); record["kubernetes"].delete("pod_id"); record["kubernetes"].delete("namespace_labels"); record["kubernetes"].delete("container_info"); record["kubernetes"].delete("labels"); record.delete("container_name"); record.delete("pod_name"); record["kubernetes"].delete("container_image_id"); record["kubernetes"].delete("host"); record.delete("container_info"); record.delete("docker")}
@@ -24,7 +24,7 @@ data:
     </filter>
 
     # Move nested records to toplevel to be used as buffer key
-    <filter kubernetes.var.log.containers.**{{ .Release.Namespace }}**>
+    <filter **>
       @type record_modifier
       <record>
         pod_name ${record["kubernetes"]["pod_name"]}
@@ -35,7 +35,7 @@ data:
     </filter>
 
     # Output to S3
-    <match kubernetes.var.log.containers.**{{ .Release.Namespace }}**>
+    <match **>
       # Docs: https://github.com/fluent/fluent-plugin-s3
       @type s3
       @log_level info


### PR DESCRIPTION
We can not use this with our fluentd version. 
`reloader time="2020-10-16T10:44:54Z" level=info msg="Configuration for namespace codacy-dev cannot be validated: bad tag for <filter>: kubernetes.var.log.containers.**codacy-dev**. Tag must start with **, $thisns or codacy-dev"`
A new ticket has been raised to address this issue