### PR TITLE
doc: Move how to install a custom Codacy version to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ Replace the `<codacy-doks-cluster>` with the name of your target cluster.
 $ doctl kubernetes cluster kubeconfig save <codacy-doks-cluster> --set-current-context
 ```
 
-## Deploy your version of a component
+### Deploy your version of a component
 
 You can deploy your version of a component using any of the `.circleci`
 pipelines we have set up in this project. Currently, we use the `hourly_pipeline`
@@ -309,10 +309,28 @@ for this purpose.
 5.  Follow the circleci pipeline and use kubectl to see if your installation was successful
 6.  Go to <http://sandbox.k8s.dev.codacy.org/> and test it out
 
-## Add a new component
+### Add a new component
 
 To add a new component on this chart, you need to:
 
 1.  Change the `requirements.yaml`
 2.  use the `helm dep up codacy/` command to update the `requirements.lock`
 3.  `git push`
+
+### Installing a custom Codacy version
+
+To install a custom Codacy version:
+
+```bash
+sudo git clone git://github.com/codacy/chart -b <YOUR-BRANCH>
+helm dep build ./chart/codacy
+helm upgrade --install codacy ./chart/codacy/ --namespace codacy --atomic --timeout=300 --values ./<YOUR-VALUES-FILE>
+```
+
+To upgrade a custom Codacy version:
+
+```bash
+(cd chart; sudo git fetch --all --prune --tags; sudo git reset --hard origin/<YOUR-BRANCH>;)
+helm dep build ./chart/codacy
+helm upgrade --install codacy ./chart/codacy/ --namespace codacy --atomic --timeout=300 --values ./<YOUR-VALUES-FILE>
+```

--- a/docs/troubleshoot/k8s-cheatsheet.md
+++ b/docs/troubleshoot/k8s-cheatsheet.md
@@ -1,30 +1,10 @@
 # Kubernetes cheatsheet
 
-## How to install a custom Codacy version
-
-### Install
-
-```bash
-sudo git clone git://github.com/codacy/chart -b <YOUR-BRANCH>
-helm dep build ./chart/codacy
-helm upgrade --install codacy ./chart/codacy/ --namespace codacy --atomic --timeout=300 --values ./<YOUR-VALUES-FILE>
-```
-
-### Upgrade
-
-```bash
-(cd chart; sudo git fetch --all --prune --tags; sudo git reset --hard origin/<YOUR-BRANCH>;)
-helm dep build ./chart/codacy
-helm upgrade --install codacy ./chart/codacy/ --namespace codacy --atomic --timeout=300 --values ./<YOUR-VALUES-FILE>
-```
-
-## Debugging 
+## Debugging using events
 
 !!! important
     Always check the pods and deployment versions in the namespace
     to make sure you are not debugging an issue in a version that is not the one you would expect
-
-### Events
 
 Events are a great way to understand what is going on under the hood in a Kubernetes cluster.
 By looking at them you can see if probes are failing, and other important signals from your cluster.


### PR DESCRIPTION
Since these instructions are useful when developing Codacy, it makes more sense to include them directly in the README.md of the repository than in the [customer-facing documentation](https://docs.codacy.com/chart/troubleshoot/k8s-cheatsheet/).

For more information, see the Slack discussion: https://codacy.slack.com/archives/C8X9SS1H7/p1604403487009700