### PR TITLE
fix: Changed documentation version process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -317,10 +317,9 @@ jobs:
     steps:
       - checkout
       - run:
-          name: setup version from git tag
+          name: Setup version from git tag
           command: |
-            git tag --sort creatordate | grep -E "^([0-9]+\.[0-9]+\.[0-9]+)-RC.*" | tail -n -1 > .version
-            echo $(cat .version)
+            make create_version_file
       - <<: *persist_to_workspace
 
   create_dev_cluster:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -317,7 +317,7 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Setup version from git tag
+          name: Set up version from git tag
           command: |
             make create_version_file
       - <<: *persist_to_workspace

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ codacy/tmpcharts
 
 # Automated generation of changelogs and release notes
 release-notes-tools
+
+# explicitly ignore the version file
+.version

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,3 @@
-CODACY_VERSION_NUMBER?=$(shell sed -e 's/.*/v&/g' .version || echo "development")
-DOCUMENTATION_VERSION_NUMBER?=$(shell sed -e 's/.*/v&/g' .version | grep -Eoh "^v([0-9]+\.[0-9]+)" || echo "development")
-
 .PHONY: setup_helm_repos
 setup_helm_repos:
 	helm repo add bitnami https://charts.bitnami.com/bitnami
@@ -11,15 +8,29 @@ setup_helm_repos:
 	helm repo add codacy-external https://charts.codacy.com/external
 	helm repo update
 
-.PHONY: update_versions
-update_versions:
+.PHONY: create_version_file
+create_version_file:
+	@if [ ! -e .version ]; \
+	then echo "Creating .version file based on the most recent tag..."; \
+	git tag --sort creatordate | grep -E "^([0-9]+\.[0-9]+\.[0-9]+)-RC.*" | tail -n -1 > .version; \
+	cat .version; \
+	else echo ".version file already exists..."; \
+	fi
+
+.PHONY: update_internals_versions
+update_internals_versions:
 	$(eval ENGINE_VERSION=$(shell grep "engine" -A 2 codacy/requirements.lock | grep version | cut -d : -f 2 | tr -d '[:blank:]'))
-	@echo ${ENGINE_VERSION}
-	@echo ${CODACY_VERSION_NUMBER}
-	# Values used by codacy-api
+	@echo "Engine version: ${ENGINE_VERSION}"
+	ytool -f "./codacy/values.yaml" -s global.workerManager.workers.config.imageVersion "${ENGINE_VERSION}" -e
+
+.PHONY: update_docs_versions
+update_docs_versions:
+	$(eval CODACY_VERSION_NUMBER=$(shell sed -e 's/.*/v&/g' .version || echo "development"))
+	$(eval DOCUMENTATION_VERSION_NUMBER=$(shell sed -e 's/.*/v&/g' .version | grep -Eoh "^v([0-9]+\.[0-9]+)" || echo "development"))
+	@echo "Codacy version: ${CODACY_VERSION_NUMBER}"
+	@echo "Documentation version: ${DOCUMENTATION_VERSION_NUMBER}"
 	ytool -f "./codacy/values.yaml" -s global.codacy.installation.version "${CODACY_VERSION_NUMBER}" -e
 	ytool -f "./codacy/values.yaml" -s global.codacy.documentation.version "${DOCUMENTATION_VERSION_NUMBER}" -e
-	ytool -f "./codacy/values.yaml" -s global.workerManager.workers.config.imageVersion "${ENGINE_VERSION}" -e
 
 .PHONY: helm_dep_up
 helm_dep_up:
@@ -27,7 +38,7 @@ helm_dep_up:
 	ls -l codacy/charts/
 
 .PHONY: update_dependencies
-update_dependencies: setup_helm_repos helm_dep_up update_versions
+update_dependencies: setup_helm_repos helm_dep_up update_internals_versions update_docs_versions
 
 .PHONY: get_release_notes
 get_release_notes: setup_helm_repos helm_dep_up

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -78,9 +78,10 @@ The Release Manager must create a release candidate branch:
     make create_version_file update_dependencies
     ```
 
-    First, a `.version` file will be created based off of the most recently created tag, which is the one you have created on the previous step.
+    These Makefile targets:
 
-    Then, the command will update the `requirements.lock` with the latest versions and freeze the `global.workers.config.imageVersion` version on `./codacy/values.yaml`.
+    -   Create a `.version` file based on the most recent tag that you created on the previous step.
+    -   Update the `requirements.lock` with the latest versions and freeze the `global.workers.config.imageVersion` version on `./codacy/values.yaml`.
 
     This will also update the `global.codacy.installation.version` and `global.codacy.documentation.version` version on `./codacy/values.yaml`.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -58,27 +58,7 @@ The Release Manager must create a release candidate branch:
     git checkout -b 'release-x.x.x'
     ```
 
--   [ ] 4.  Update Dependencies
-
-    Let's assume that `requirements.yaml` file should have the correct dynamic versions configured.
-
-    Run the following command:
-
-    ```bash
-    make update_dependencies
-    ```
-
-    This will update the `requirements.lock` with the latest versions and freeze the `global.workers.config.imageVersion` version on `./codacy/values.yaml`.
-
--   [ ] 5.  Commit the updated `requirements.lock` and `./codacy/values.yaml` to the branch
-
-    For example:
-
-    ```bash
-    git commit -m 'release: prepare x.x.x'
-    ```
-
--   [ ] 6.  Tag the commit with a release candidate version following the pattern `x.x.x-RC-0`
+-   [ ] 4.  Tag the commit with a release candidate version following the pattern `x.x.x-RC-0`
 
     For example:
 
@@ -86,9 +66,43 @@ The Release Manager must create a release candidate branch:
     git tag 'x.x.x-RC-1'
     ```
 
-    This version will be published to the [incubator](https://charts.codacy.com/incubator/api/charts) channel in the next step.
+    This is a requirement so that we can fill in values for `engine` and `documentation` versions on the next step.
 
--   [ ] 7.  Push the commit
+-   [ ] 5.  Update Dependencies
+
+    Let's assume that `requirements.yaml` file should have the correct dynamic versions configured.
+
+    Run the following command:
+
+    ```bash
+    make create_version_file update_dependencies
+    ```
+
+    First, a `.version` file will be created based off of the most recently created tag, which is the one you have created on the previous step.
+
+    Then, the command will update the `requirements.lock` with the latest versions and freeze the `global.workers.config.imageVersion` version on `./codacy/values.yaml`.
+
+    This will also update the `global.codacy.installation.version` and `global.codacy.documentation.version` version on `./codacy/values.yaml`.
+
+-   [ ] 6.  Commit the updated `requirements.lock` and `./codacy/values.yaml` to the branch
+
+    For example:
+
+    ```bash
+    git commit -m 'release: prepare x.x.x'
+    ```
+
+-   [ ] 7.  Move the the tag to the latest commit you have just done
+
+    For example:
+
+    ```bash
+    git tag -f 'x.x.x-RC-1'
+    ```
+
+    This version will be published to the [incubator](https://charts.codacy.com/incubator/api/charts) channel in the next steps.
+
+-   [ ] 8.  Push the commit
 
     ```bash
     git push origin refs/tags/x.x.x-RC-1 && git push --set-upstream origin 'release-x.x.x'
@@ -98,7 +112,7 @@ The Release Manager must create a release candidate branch:
 
     Your chart will be deployed to [the release environment described in this table](README.md#development-installations).
 
-    -   [ ] 7.1.  Cherry-pick fixes
+    -   [ ] 8.1.  Cherry-pick fixes
 
         At this stage, it is possible for the build to have failed. The fixes for this failure should have been merged to `master` following a successfully approved Pull Request.
 
@@ -110,7 +124,7 @@ The Release Manager must create a release candidate branch:
 
         Ensure the cherry-pick commit is free from any conflicts.
 
-    -   [ ] 7.2.  Push new Release Candidate tag
+    -   [ ] 8.2.  Push new Release Candidate tag
 
         Since there are new hotfix changes to the release, you must then add another release candidate tag to your release branch and push it again.
 


### PR DESCRIPTION
If no .version file exists, one should be created.
This should address the issue of cutting releases from a local machine, when no .version file exists.