### PR TITLE
Add repositoriesLimit to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ The following parameters are specific to each Codacy component.
 | `codacy-spa.image.tag`                              | Image tag                                                                                           | from dependency                              |
 | `codacy-spa.service.type`                           | SPA service type                                                                                    | `ClusterIP`                                  |
 | `codacy-spa.service.annotations`                    | Annotations to be added to the SPA service                                                          | `{}`                                         |
+| `codacy-spa.config.codacy.pagination.repositoriesLimit`   | Amount of repositories to fetch on each page                                                  | `100`                              |
 
 The following parameters refer to components that are not internal to Codacy, but go as part of this bundle so that you can bootstrap Codacy faster.
 


### PR DESCRIPTION
Adds documentation on the path to override the repositoriesLimit value.
Default 100 that comes from the repo, we don't want to change this number.
This is an added option for really slow repositories list before the next improvements.

Configuration already live in prod at https://github.com/codacy/codacy-spa/blob/dev/.helm/codacy-spa/values.yaml#L76
It felt that it could fit under the "config", but now it seems a bit different from the other components, let me know what you guys think