### PR TITLE
clean: Refactor and improve "Collecting logs for Support"

### DIFF
--- a/docs/troubleshoot/logs-collect.md
+++ b/docs/troubleshoot/logs-collect.md
@@ -2,22 +2,26 @@
 
 To help troubleshoot issues, obtain the logs from your Codacy instance and send them to Codacy's Support:
 
-1.  Download the logs of the last 7 days as an archive file with the name `codacy_logs_<timestamp>.zip` by running the following command locally, replacing `<namespace>` with the namespace in which Codacy was installed:
+1.  Run the following command on a machine with network access to the Codacy cluster, replacing `<namespace>` with the namespace in which Codacy was installed:
 
     ```bash
     bash <(curl -fsSL https://raw.githubusercontent.com/codacy/chart/master/docs/troubleshoot/extract-codacy-logs.sh) \
         -n <namespace>
     ```
 
-    To reduce the size of the compressed archive file, you should retrieve logs for a smaller number of days by replacing `<days>` with a number between 1 and 7:
+    This will download the logs of the last 7 days as an archive file with the name `codacy_logs_<timestamp>.zip`.
 
-    ```bash
-    bash <(curl -fsSL https://raw.githubusercontent.com/codacy/chart/master/docs/troubleshoot/extract-codacy-logs.sh) \
-        -n <namespace> -d <days>
-    ```
-
-    You can also download the script [extract-codacy-logs.sh](extract-codacy-logs.sh) to run it manually.
+    !!! tip
+        You can also download the script [extract-codacy-logs.sh](extract-codacy-logs.sh) to run it manually.
 
 2.  Send the compressed logs to Codacy's support team at [support@codacy.com](mailto:support@codacy.com) for analysis.
 
-    If the file is too big, please upload the file to either a cloud storage service such as [Google Drive](https://www.google.com/drive/) or to a file transfer service such as [WeTransfer](http://www.wetransfer.com/) and send us the link to the file instead.
+    !!! note
+        If the file is too big, please upload the file to either a cloud storage service such as [Google Drive](https://www.google.com/drive/) or to a file transfer service such as [WeTransfer](http://www.wetransfer.com/) and send us the link to the file instead.
+
+        Alternatively, to reduce the size of the compressed archive file, retrieve logs for a smaller number of days by replacing `<days>` with a number between 1 and 7:
+
+        ```bash
+        bash <(curl -fsSL https://raw.githubusercontent.com/codacy/chart/master/docs/troubleshoot/extract-codacy-logs.sh) \
+            -n <namespace> -d <days>
+        ```


### PR DESCRIPTION
It wasn't clear for a customer where the command that collected the logs should run:

https://codacy.slack.com/archives/CQESXTUHW/p1609956509001900

Besides clarifying this, I also reorganized the page to make the main procedure of collecting logs simpler, and placing all information related to the potential size of the archive being too big at the bottom inside a note:

![image](https://user-images.githubusercontent.com/60105800/103884757-ecbd8980-50d6-11eb-8130-df7a24a18fd8.png)
