### PR TITLE
fix[eks]: Use the cluster name in the log_group name

### DIFF
--- a/docs/infrastructure/EKS/main/cluster_masters.tf
+++ b/docs/infrastructure/EKS/main/cluster_masters.tf
@@ -78,7 +78,7 @@ resource "aws_iam_role_policy_attachment" "eks_cluster" {
 
 ### cloudwatch control plane logs
 resource "aws_cloudwatch_log_group" "eks" {
-  name              = "/aws/eks/${var.project_slug}/cluster"
+  name              = "/aws/eks/${var.project_slug}-cluster/cluster"
   retention_in_days = 7
   tags              = var.custom_tags
 }


### PR DESCRIPTION
There is an error in the log_group name, which implies the retention policy isn't applied to the cluster log_group, causing the logs to accumulate over time.