### PR TITLE
fix[eks]: add comment suggesting a fix for the terraform k8s provider error

### DIFF
--- a/docs/infrastructure/EKS/main/config.tf
+++ b/docs/infrastructure/EKS/main/config.tf
@@ -30,6 +30,10 @@ provider "kubernetes" {
   host                   = aws_eks_cluster.main.endpoint
   cluster_ca_certificate = base64decode(aws_eks_cluster.main.certificate_authority.0.data)
   token                  = data.aws_eks_cluster_auth.eks_cluster_auth.token
+  # Change `load_config_file` to `true` if,  when reapplying, you obtain an error with content similar to:
+  #
+  # Error: configmaps "aws-auth" is forbidden: User "system:anonymous" cannot get resource "configmaps" in API group "" in the namespace "kube-system"
+  #
   load_config_file       = false
   version                = "~> 1.5"
 }


### PR DESCRIPTION
I had an issue when trying to deploy changes to the k8s cluster, which caused an error with the following message:

```
Error: configmaps "aws-auth" is forbidden: User "system:anonymous" cannot get resource "configmaps" in API group "" in the namespace "kube-system"
```

Setting  `load_config_file = true` fixes it.

I don't think it's a good idea to change this by default, because it might break the deployment from scratch. But maybe it would be nice to add this comment here, to help solve the issue if it ever happens with someone else.