### PR TITLE
doc: Fix broken table in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,17 +234,14 @@ The following parameters are specific to each Codacy component.
 
 The following parameters refer to components that are not internal to Codacy, but go as part of this bundle so that you can bootstrap Codacy faster.
 
-| Parameter                            | Description                                                                                                    | Default           |
-| ------------------------------------ | -------------------------------------------------------------------------------------------------------------- | ----------------- |
-| `fluentdoperator.enable`             | Enable fluentd operator. It gathers logs from Codacy so that you can send it to our support if needed.         | `true`            |
-| `fluentdoperator.expirationDays`     | Number of days to retain logs. More time uses more disk on minio and retention over 7 days is not recommended. | `7`               |
-| `fluentdoperator.flushTimeout`       | Maximum time until Fluentd stops retrying to flush the logs. Values must be expressed using a unit, e.g. `10s`, `5h`. | `1h`               |
-
-
-
-| `rabbitmq-ha.rabbitmqUsername`       | Username for the bundled RabbitMQ.                                                                             | `rabbitmq-codacy` |
-| `rabbitmq-ha.rabbitmqPassword`       | Password for the bundled RabbitMQ.                                                                             | `rabbitmq-codacy` |
-| `rabbitmq-ha.rabbitmqErlangCookie`   | The rabbitmq Erlang cookie RabbitMQ.                                                                           | `nil`             |
+| Parameter                            | Description                                                                                                           | Default           |
+| ------------------------------------ | --------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| `fluentdoperator.enable`             | Enable fluentd operator. It gathers logs from Codacy so that you can send it to our support if needed.                | `true`            |
+| `fluentdoperator.expirationDays`     | Number of days to retain logs. More time uses more disk on minio and retention over 7 days is not recommended.        | `7`               |
+| `fluentdoperator.flushTimeout`       | Maximum time until Fluentd stops retrying to flush the logs. Values must be expressed using a unit, e.g. `10s`, `5h`. | `1h`              |
+| `rabbitmq-ha.rabbitmqUsername`       | Username for the bundled RabbitMQ.                                                                                    | `rabbitmq-codacy` |
+| `rabbitmq-ha.rabbitmqPassword`       | Password for the bundled RabbitMQ.                                                                                    | `rabbitmq-codacy` |
+| `rabbitmq-ha.rabbitmqErlangCookie`   | The rabbitmq Erlang cookie RabbitMQ.                                                                                  | `nil`             |
 
 You can also configure values for the PostgreSQL database via the Postgresql [README.md](https://github.com/kubernetes/charts/blob/master/stable/postgresql/README.md)
 


### PR DESCRIPTION
Fixes a broken table in the README:

![image](https://user-images.githubusercontent.com/60105800/106761593-e3b7cd80-662c-11eb-9236-1dac4151217e.png)
