### PR TITLE
doc: Fix mailto: link syntax

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -41,7 +41,7 @@ The cluster must be configured to accept and establish connections on the follow
 
 The high-level architecture described in the next section is important in understanding how Codacy uses and allocates hardware resources. Below we also provide guidance on [resource provisioning for typical scenarios](#standard-cluster-provisioning).
 
-For a custom hardware resource recommendation, please contact us at [support@codacy.com](mailto:support@codacy.com).
+For a custom hardware resource recommendation, please contact us at <mailto:support@codacy.com>.
 
 #### Codacy architecture
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -41,7 +41,7 @@ The cluster must be configured to accept and establish connections on the follow
 
 The high-level architecture described in the next section is important in understanding how Codacy uses and allocates hardware resources. Below we also provide guidance on [resource provisioning for typical scenarios](#standard-cluster-provisioning).
 
-For a custom hardware resource recommendation, please contact us at [support@codacy.com](mailto://support@codacy.com).
+For a custom hardware resource recommendation, please contact us at [support@codacy.com](mailto:support@codacy.com).
 
 #### Codacy architecture
 

--- a/docs/troubleshoot/logs-collect.md
+++ b/docs/troubleshoot/logs-collect.md
@@ -14,7 +14,7 @@ To help troubleshoot issues, obtain the logs from your Codacy instance and send 
     !!! tip
         You can also download the script [extract-codacy-logs.sh](extract-codacy-logs.sh) to run it manually.
 
-2.  Send the compressed logs to Codacy's support team at [support@codacy.com](mailto:support@codacy.com) for analysis.
+2.  Send the compressed logs to Codacy's support team at <mailto:support@codacy.com> for analysis.
 
     !!! note
         If the file is too big, please upload the file to either a cloud storage service such as [Google Drive](https://www.google.com/drive/) or to a file transfer service such as [WeTransfer](http://www.wetransfer.com/) and send us the link to the file instead.

--- a/docs/troubleshoot/troubleshoot.md
+++ b/docs/troubleshoot/troubleshoot.md
@@ -2,7 +2,7 @@
 
 This page includes information to help you troubleshoot issues that you may come across while installing, configuring, and operating Codacy.
 
-If the information provided on this page is not enough to solve your issue, contact [support@codacy.com](mailto:support@codacy.com) providing:
+If the information provided on this page is not enough to solve your issue, contact <mailto:support@codacy.com> providing:
 
 -   The description of the issue
 -   All the information that you were able to obtain while following these troubleshooting instructions


### PR DESCRIPTION
Fixes incorrect syntax of link to Support email address, and simplifies the Markdown syntax for all email links.