### PR TITLE
clean: Rename repository containing release notes tools DOCS-129

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,7 @@ codacy/charts
 codacy/tmpcharts
 
 # Automated generation of changelogs and release notes
-release-notes-tools
+codacy-tools-release-notes
 
 # explicitly ignore the version file
 .version

--- a/Makefile
+++ b/Makefile
@@ -44,12 +44,12 @@ update_dependencies: setup_helm_repos helm_dep_up update_internals_versions upda
 get_release_notes: setup_helm_repos helm_dep_up
 	# Fetch updated codacy/chart tags
 	git fetch --all --tags
-	# Cleanup release-notes-tools if it exists
-	if [ -d release-notes-tools ]; then rm -rf release-notes-tools; fi
-	# Clone codacy/release-notes-tools and generate the changelog and release notes
-	git clone git@github.com:codacy/release-notes-tools.git
+	# Cleanup codacy-tools-release-notes if it exists
+	if [ -d codacy-tools-release-notes ]; then rm -rf codacy-tools-release-notes; fi
+	# Clone codacy/codacy-tools-release-notes and generate the changelog and release notes
+	git clone git@github.com:codacy/codacy-tools-release-notes.git
 	# Install dependencies
-	pip3 install -r release-notes-tools/requirements.pip --user
+	pip3 install -r codacy-tools-release-notes/requirements.pip --user
 	# Generate changelogs and release notes
-	release-notes-tools/getChangelogs.sh ${CURDIR}/codacy/requirements.yaml \
+	codacy-tools-release-notes/getChangelogs.sh ${CURDIR}/codacy/requirements.yaml \
 	                                     ${CURDIR}/codacy/requirements.lock

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -185,13 +185,13 @@ The Technical Writer must follow the steps below to [prepare the release notes](
     make get_release_notes
     ```
 
-    This uses [codacy/release-notes-tools](https://github.com/codacy/release-notes-tools) to generate the files `releasenotes.md` and `missingreleasenotes.md`.
+    This uses [codacy/codacy-tools-release-notes](https://github.com/codacy/codacy-tools-release-notes) to generate the files `releasenotes.md` and `missingreleasenotes.md`.
 
 -   [ ] 2.  Manually curate the generated release notes output
 
     Make adjustments directly on the corresponding Jira Epics and Bugs, and generate the release notes again to collect the most up-to-date information from Jira.
 
--   [ ] 3.  Generate the tool versions and updates for the new release by following the instructions on [codacy/codacy-tools-release-notes](https://github.com/codacy/codacy-tools-release-notes).
+-   [ ] 3.  Generate the tool versions and updates for the new release by following the instructions on [codacy/codacy-tools-release-notes](https://github.com/codacy/codacy-tools-release-notes/blob/master/tools-diff/README.md).
 
 -   [ ] 4.  Review the release notes on a new pull request in codacy/docs
 


### PR DESCRIPTION
See [DOCS-129](https://codacy.atlassian.net/browse/DOCS-129) for more information.

I decided to rename the repository containing the tools related to release notes generation to `codacy-tools-release-notes` as it is a bit more tidy and consistent with the naming of other Codacy repositories.