### PR TITLE
fix: Update relative URL to absolute

### DIFF
--- a/docs/maintenance/upgrade.md
+++ b/docs/maintenance/upgrade.md
@@ -2,7 +2,7 @@
 
 To upgrade Codacy to the latest stable version:
 
-1.  Check the [release notes](/release-notes/) for all Codacy Self-hosted versions between your current version and the most recent version for breaking changes and follow the instructions provided carefully.
+1.  Check the [release notes](https://docs.codacy.com/release-notes/) for all Codacy Self-hosted versions between your current version and the most recent version for breaking changes and follow the instructions provided carefully.
 
     !!! warning
         Failing to follow the steps to deal with breaking changes can cause the upgrade to fail or cause problems while Codacy is running.


### PR DESCRIPTION
The relative URL starting at the root passed unnoticed under the MkDocs tests (as intended), but made the validation of the links on the generated HTML fail:

https://github.com/codacy/docs/commit/e31b809428f9ab7b5eedac60a80fb36376c3bfbe