### PR TITLE
doc: Change title of "Emails" to "SMTP server" DOCS-253

### DIFF
--- a/docs/configuration/integrations/email.md
+++ b/docs/configuration/integrations/email.md
@@ -2,7 +2,7 @@
 description: Instructions on how to set up Codacy Self-hosted to send emails using your SMTP server.
 ---
 
-# Emails
+# SMTP server
 
 Follow the instructions below to set up Codacy Self-hosted to send emails using your SMTP server:
 


### PR DESCRIPTION
This is to avoid having two pages with the same title because of the change in https://github.com/codacy/docs/pull/671.

I decided not to change the actual filename for this page so that we don't have to deal with broken links. 🔗