### PR TITLE
doc: Fix chart version when upgrading Codacy Self-hosted

### DIFF
--- a/docs/maintenance/upgrade.md
+++ b/docs/maintenance/upgrade.md
@@ -33,6 +33,7 @@ To upgrade Codacy Self-hosted to the latest stable version:
 
     ```bash
     helm upgrade codacy codacy-stable/codacy \
+                 --version {{ version }} \
                  --namespace codacy \
                  --values codacy.yaml
     ```

--- a/docs/maintenance/upgrade.md
+++ b/docs/maintenance/upgrade.md
@@ -32,6 +32,7 @@ To upgrade Codacy Self-hosted to the latest stable version:
 4.  Perform the upgrade using the values stored in the file:
 
     ```bash
+    helm repo update
     helm upgrade codacy codacy-stable/codacy \
                  --version {{ version }} \
                  --namespace codacy \


### PR DESCRIPTION
This uses a variable that contains the chart version/tag for the current documentation version, for example, `3.5.1`.

I believe it's best to have the version explicit [on the documentation](https://docs.codacy.com/chart/maintenance/upgrade/), as customers can always change the version or remove the flag `--version` completely if they wish.

This makes the instructions more explicit / safer for the cases when we release patches or minor versions out of the usual "version order".