### PR TITLE
clean: Update Makefile target get_release_notes DOCS-269

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,4 +52,4 @@ get_release_notes:
 	# Fetch updated codacy/chart tags
 	git fetch --all --tags --force
 	# Generate changelog and release notes
-	codacy-tools-release-notes/run.sh ${VERSION_NEW} ${VERSION_OLD} --push
+	codacy-tools-release-notes/run.sh selfhosted ${VERSION_NEW} ${VERSION_OLD} --push


### PR DESCRIPTION
Adds the new command `selfhosted` to specify generating release notes for Codacy Self-hosted:

https://github.com/codacy/codacy-tools-release-notes#generating-codacy-self-hosted-release-notes

(See https://github.com/codacy/codacy-tools-release-notes/pull/49 for more information.)