### PR TITLE
doc: Highlight disabling expiring tokens

### DIFF
--- a/docs/configuration/integrations/github-app-create.md
+++ b/docs/configuration/integrations/github-app-create.md
@@ -15,7 +15,7 @@ To create the GitHub App:
     | GitHub App name                         | Codacy                                                  |
     | Homepage URL                            | `https://codacy.example.com`                            |
     | User authorization callback URL         | `https://codacy.example.com`                            |
-    | Expire user authorization tokens        | Disabled<br/><br/><strong>Note:</strong> Currently, Codacy doesn't support <a href="https://docs.github.com/en/developers/apps/building-github-apps/refreshing-user-to-server-access-tokens">expiring user access tokens</a>. Make sure that this option is turned off. |
+    | Expire user authorization tokens        | Disabled<br/><br/><strong>⚠️ Note:</strong> Currently, Codacy doesn't support <a href="https://docs.github.com/en/developers/apps/building-github-apps/refreshing-user-to-server-access-tokens" target="_blank">expiring user access tokens</a>. Make sure that this option is turned off. |
     | Webhook URL                             | For GitHub Cloud:<br/>`https://codacy.example.com/2.0/events/gh/organization`<br/><br/>For GitHub Enterprise:<br/>`https://codacy.example.com/2.0/events/ghe/organization` |
     | **Repository permissions**              |                                                         |
     | Administration                          | Read & write                                            |

--- a/docs/configuration/integrations/github-app-create.md
+++ b/docs/configuration/integrations/github-app-create.md
@@ -15,7 +15,7 @@ To create the GitHub App:
     | GitHub App name                         | Codacy                                                  |
     | Homepage URL                            | `https://codacy.example.com`                            |
     | User authorization callback URL         | `https://codacy.example.com`                            |
-    | Expire user authorization tokens        | Disabled                                                |
+    | Expire user authorization tokens        | Disabled<br/><br/><strong>Note:</strong> Currently, Codacy doesn't support <a href="https://docs.github.com/en/developers/apps/building-github-apps/refreshing-user-to-server-access-tokens">expiring user access tokens</a>. Make sure that this option is turned off. |
     | Webhook URL                             | For GitHub Cloud:<br/>`https://codacy.example.com/2.0/events/gh/organization`<br/><br/>For GitHub Enterprise:<br/>`https://codacy.example.com/2.0/events/ghe/organization` |
     | **Repository permissions**              |                                                         |
     | Administration                          | Read & write                                            |


### PR DESCRIPTION
Even though the page on [how to create a GitHub App](https://docs.codacy.com/chart/configuration/integrations/github-app-create/) already included the indication to disable the option **Expire user authorization tokens**, we've been finding that some customers configure this option incorrectly.

This pull request adds a note to call the attention of customers to this setting:

![image](https://user-images.githubusercontent.com/60105800/129049565-2ebb96d4-de54-4b24-9587-17c997bf4775.png)
