### PR TITLE
fix: Update release notes repository name in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,7 @@ codacy/charts
 codacy/tmpcharts
 
 # Automated generation of changelogs and release notes
-codacy-tools-release-notes
+release-notes-tools
 
 # explicitly ignore the version file
 .version


### PR DESCRIPTION
I missed this update on https://github.com/codacy/chart/pull/697.