### PR TITLE
doc: Mention publishing a new docs version in RELEASE.md

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -252,7 +252,9 @@ Then, the Release Manager releases and announces the new version:
 
 -   [ ] 3.  Inform all stakeholders that the release is finished
 
-The final version will be `x.x.x`.
+    The final version will be `x.x.x`.
+
+-   [ ] 4. Finally, the Technical Writer must [release a version of the documentation for the new Codacy Self-hosted version](https://github.com/codacy/docs/blob/master/CONTRIBUTING.md#releasing-a-new-version-of-the-documentation).
 
 ## Patching a release
 


### PR DESCRIPTION
Releasing a new version of the documentation is necessary to ensure that customers have access to the documentation that is in sync with their Codacy Self-hosted version:

![sshot](https://user-images.githubusercontent.com/60105800/134027070-03c479d1-ced5-403e-9efb-0b32ee14f1e4.png)


