### PR TITLE
feature: Add notices regarding drop of legacy organizations in 5.0.0

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,9 @@ description: Install and configure Codacy Self-hosted on Kubernetes or MicroK8s.
 
 This documentation guides you on how to install Codacy Self-hosted on Kubernetes or MicroK8s.
 
+!!! important
+    **If you're running the legacy Codacy Self-hosted solution running on Docker** please contact <mailto:support@codacy.com> so that we can assist you with the migration to Codacy Self-hosted running on Kubernetes or MicroK8s.
+
 To install Codacy you must complete these main steps:
 
 1.  **Setting up the system requirements**

--- a/docs/maintenance/upgrade.md
+++ b/docs/maintenance/upgrade.md
@@ -11,6 +11,8 @@ To upgrade Codacy Self-hosted to the latest stable version:
     !!! warning
         Failing to follow the steps to deal with breaking changes can cause the upgrade to fail or cause problems while Codacy is running.
 
+        **In particular, [Codacy Self-hosted v5.0.0](https://docs.codacy.com/release-notes/self-hosted/self-hosted-v5.0.0/) drops the support for legacy manual organizations**.
+
     {%
         include-markdown "../assets/includes/self-hosted-version.txt"
     %}


### PR DESCRIPTION
Adds the notices below to the Codacy Self-hosted installation and upgrade documentation to help catch scenarios where customers may be using the legacy solution running on Docker or using legacy manual organizations.

Let me know if you think this is enough or if you feel we need something even more visible/explicit.

![image](https://user-images.githubusercontent.com/60105800/146052173-386a1525-47e5-4a7e-8497-690514ef25ae.png)

![image](https://user-images.githubusercontent.com/60105800/146052188-c6f05177-5f8b-4ebf-b60a-a877a429edb6.png)
