### PR TITLE
bump: Bump codacy/base orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/base@5.1.3
+  codacy: codacy/base@6.1.4
   slack: circleci/slack@3.4.2
 
 references:


### PR DESCRIPTION
Needed because of CircleCI base images deprecation