### PR TITLE
doc: Point release notes link directly to Self-hosted releases

### DIFF
--- a/docs/maintenance/upgrade.md
+++ b/docs/maintenance/upgrade.md
@@ -6,7 +6,7 @@ description: Instructions on how to upgrade Codacy Self-hosted to the latest sta
 
 To upgrade Codacy Self-hosted to the latest stable version:
 
-1.  Check the [release notes](https://docs.codacy.com/release-notes/) for all Codacy Self-hosted versions between your current version and the most recent version for breaking changes and follow the instructions provided carefully.
+1.  [Check the release notes](https://docs.codacy.com/release-notes/#self-hosted) for all Codacy Self-hosted versions between your current version and the most recent version for breaking changes and follow the instructions provided carefully.
 
     !!! warning
         Failing to follow the steps to deal with breaking changes can cause the upgrade to fail or cause problems while Codacy is running.


### PR DESCRIPTION
Small improvement to help customers navigate more quickly to the relevant release notes.