### PR TITLE
feature: Add troubleshooting for missing new tools

### DIFF
--- a/docs/troubleshoot/troubleshoot.md
+++ b/docs/troubleshoot/troubleshoot.md
@@ -123,3 +123,11 @@ If you need to access the RabbitMQ dashboard:
 
     -   **Username:** `rabbitmq-codacy`
     -   **Password:** `rabbitmq-codacy`
+
+## Missing new tools
+
+If the **Code patterns** page of your repositories doesn't list a new tool that was included in a new Codacy version, force the list of available tools to refresh by running the following command on any `codacy-engine-*` pod:
+
+```bash
+curl -X POST localhost:9000/api/v1/engine/initialize
+```


### PR DESCRIPTION
Addresses [this scenario](https://codacy.slack.com/archives/CE6SW4LAU/p1648722558591649?thread_ts=1648478392.672249&cid=CE6SW4LAU) where the list of tools may fail to update automatically after upgrading the Codacy Self-hosted version.