### PR TITLE
doc: Update link to moved page on GitHub documentation

### DIFF
--- a/docs/configuration/integrations/github-app-create.md
+++ b/docs/configuration/integrations/github-app-create.md
@@ -1,6 +1,6 @@
 # Creating a GitHub App
 
-You must create and correctly set up a [GitHub App](https://developer.github.com/apps/about-apps/) to allow Codacy Self-hosted to integrate with GitHub.
+You must create and correctly set up a [GitHub App](https://docs.github.com/en/developers/apps/getting-started-with-apps/about-apps) to allow Codacy Self-hosted to integrate with GitHub.
 
 To create the GitHub App:
 


### PR DESCRIPTION
Fixes https://github.com/codacy/docs/issues/1241.