### PR TITLE
doc: Remove disabling expiring access tokens for GitLab Enterprise CY-6117

### DIFF
--- a/docs/configuration/integrations/gitlab-enterprise.md
+++ b/docs/configuration/integrations/gitlab-enterprise.md
@@ -25,11 +25,6 @@ To integrate Codacy with GitLab Enterprise, you must create a GitLab application
         https://codacy.example.com/add/addPermissions/GitLabEnterprise
         ```
 
-    -   **Expire access tokens:** Disable the option so that tokens don't expire.
-
-        !!! note
-            Currently, Codacy doesn't support [expiring access tokens](https://gitlab.com/help/integration/oauth_provider.md#expiring-access-tokens){: target="_blank"}. Make sure that this option is turned off.
-
     -   **Scopes:** Enable the scopes:
     
         -   `api`


### PR DESCRIPTION
[CY-6117](https://codacy.atlassian.net/browse/CY-6117) introduced support for expiring access tokens, meaning that the users no longer have to disable that option (in GitLab Enterprise versions that include it).