### PR TITLE
fix: Use historical bitnami repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: setup_helm_repos
 setup_helm_repos:
-	helm repo add bitnami https://charts.bitnami.com/bitnami
+	helm repo add bitnami-pre-2022 https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
 	helm repo add stable https://charts.helm.sh/stable
 	helm repo add codacy-stable https://charts.codacy.com/stable
 	helm repo add codacy-unstable https://charts.codacy.com/unstable

--- a/codacy/requirements-dev.yaml
+++ b/codacy/requirements-dev.yaml
@@ -7,13 +7,13 @@ dependencies:
 
 - name: rabbitmq
   version: 7.5.7
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
   condition: global.rabbitmq.create
   alias: rabbitmq-ha
 
 - name: postgresql
   version: 8.6.4
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
   alias: postgres
   condition: global.defaultdb.create, global.analysisdb.create, global.resultsdb.create,
     global.metricsdb.create, global.filestoredb.create, global.jobsdb.create

--- a/codacy/requirements.yaml
+++ b/codacy/requirements.yaml
@@ -7,13 +7,13 @@ dependencies:
 
 - name: rabbitmq
   version: 7.5.7
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
   condition: global.rabbitmq.create
   alias: rabbitmq-ha
 
 - name: postgresql
   version: 8.6.4
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
   alias: postgres
   condition: global.defaultdb.create, global.analysisdb.create, global.resultsdb.create,
     global.metricsdb.create, global.filestoredb.create, global.jobsdb.create


### PR DESCRIPTION
Bitnami has unexpectedly changed the retention policy for its charts repo, causing versions for the rabbitmq and postgresql charts we require to be missing. This PR uses the historical index for the bitnami, which includes the missing charts.

See [this issue](https://github.com/bitnami/charts/issues/10539) for further details.