### PR TITLE
fix: Use large resource class for qa tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -386,6 +386,7 @@ jobs:
 
   test_web:
     <<: *qa_automation_image
+    resource_class: large
     environment:
       <<: *qa_environment_release
       <<: *qa_selfhosted_web_testpath
@@ -393,6 +394,7 @@ jobs:
 
   test_e2e:
     <<: *qa_automation_image
+    resource_class: large
     environment:
       <<: *qa_environment_release
       <<: *qa_selfhosted_e2e_testpath
@@ -400,6 +402,7 @@ jobs:
 
   test_api:
     <<: *qa_automation_image
+    resource_class: large
     environment:
       <<: *qa_environment_release
       <<: *qa_selfhosted_api_testpath
@@ -407,6 +410,7 @@ jobs:
 
   test_apiv3:
     <<: *qa_automation_image
+    resource_class: large
     environment:
       <<: *qa_environment_release
       <<: *qa_selfhosted_apiv3_testpath


### PR DESCRIPTION
Some web tests were failing somewhat randomly. Given that they don't fail in the QA project itself, and that the difference between the two projects is the resource class size used for running them, we are increasing it here too.