### PR TITLE
doc: Add Bitbucket Server context path configuration CY-6251

### DIFF
--- a/docs/configuration/integrations/bitbucket-server.md
+++ b/docs/configuration/integrations/bitbucket-server.md
@@ -65,7 +65,7 @@ After creating the Bitbucket Server application link, you must configure it on C
        consumerKey: "" # Generated when creating the Bitbucket Server application link
        consumerPublicKey: "" # Generated when creating the Bitbucket Server application link
        consumerPrivateKey: "" # Generated when creating the Bitbucket Server application link
-       contextpath: "" # Context path of your Bitbucket Server, if configured
+       contextPath: "" # Context path of your Bitbucket Server, if configured
     ```
 
 3.  Apply the new configuration by performing a Helm upgrade. To do so execute the command [used to install Codacy](../../index.md#helm-upgrade):

--- a/docs/configuration/integrations/bitbucket-server.md
+++ b/docs/configuration/integrations/bitbucket-server.md
@@ -65,6 +65,7 @@ After creating the Bitbucket Server application link, you must configure it on C
        consumerKey: "" # Generated when creating the Bitbucket Server application link
        consumerPublicKey: "" # Generated when creating the Bitbucket Server application link
        consumerPrivateKey: "" # Generated when creating the Bitbucket Server application link
+       contextpath: "" # Context path of your Bitbucket Server, if configured
     ```
 
 3.  Apply the new configuration by performing a Helm upgrade. To do so execute the command [used to install Codacy](../../index.md#helm-upgrade):


### PR DESCRIPTION
In the context of [CY-6251](https://codacy.atlassian.net/browse/CY-6251) we added support for configuring the context path of Bitbucket Server instances.