### PR TITLE
doc: Remove disabling expiring access tokens for GitLab Cloud CY-6117

### DIFF
--- a/docs/configuration/integrations/gitlab-cloud.md
+++ b/docs/configuration/integrations/gitlab-cloud.md
@@ -25,11 +25,6 @@ To integrate Codacy with GitLab Cloud, you must create a GitLab application:
         https://codacy.example.com/add/addPermissions/GitLab
         ```
 
-    -   **Expire access tokens:** Disable the option so that tokens don't expire.
-
-        !!! note
-            Currently, Codacy doesn't support [expiring access tokens](https://gitlab.com/help/integration/oauth_provider.md#expiring-access-tokens){: target="_blank"}. Make sure that this option is turned off.
-
     -   **Scopes:** Enable the scopes:
     
         -   `api`


### PR DESCRIPTION
The GitLab Cloud setup instructions still include a note stating that Codacy doesn't support expiring access tokens because it wasn't removed in https://github.com/codacy/chart/pull/735 by mistake.