### PR TITLE
doc: Add external NFS setup instructions DOCS-393

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,10 @@ The following parameters are specific to each Codacy component.
 | `listener.nfsserverprovisioner.persistence.enabled` | Creates an NFS provisioner                                                                          | `true`                                       |
 | `listener.nfsserverprovisioner.persistence.size`    | Size of the NFS server disk                                                                         | `120Gi`                                      |
 | `listener.cacheCleanup.olderThanDays`               | Data retention policy in days                                                                       | `30`                                         |
+| `listener.cache.name`                               | External NFS volume name                                                                            | `listener-cache`                             |
+| `listener.cache.path`                               | External NFS volume mount path                                                                      | `/data`                                      |
+| `listener.cache.nfs.server`                         | IP address of external NFS server                                                                   | `0.0.0.0`                                    |
+| `listener.cache.nfs.path`                           | External NFS server directory or file system to be mounted                                          | `/`                                          |
 | `engine.replicaCount`                               | Number of replicas                                                                                  | `1`                                          |
 | `engine.image.repository`                           | Image repository                                                                                    | from dependency                              |
 | `engine.image.tag`                                  | Image tag                                                                                           | from dependency                              |

--- a/docs/configuration/caching.md
+++ b/docs/configuration/caching.md
@@ -37,3 +37,18 @@ To use your own external NFS server:
                  --values values-production.yaml \
                  # --values values-microk8s.yaml
     ```
+
+1.  Validate that the `repository-listener` pod  is now using the external NFS server:
+
+    ```bash
+    $ kubectl describe pod -n codacy codacy-listener-<...>
+
+    [...]
+
+    Volumes:
+    listener-cache:
+        Type:      NFS (an NFS mount that lasts the lifetime of a pod)
+        Server:    <NFS_SERVER_IP>
+        Path:      /var/nfs/data/
+        ReadOnly:  false
+    ```

--- a/docs/configuration/caching.md
+++ b/docs/configuration/caching.md
@@ -8,7 +8,7 @@ Codacy Self-hosted includes a built-in NFS server provisioner that deploys a sha
 
 To use your own external NFS server:
 
-1.  Edit the file `values-production.yaml` that you [used to install Codacy](../../index.md#helm-upgrade).
+1.  Edit the file `values-production.yaml` that you [used to install Codacy](../index.md#helm-upgrade).
 
 1.  Set `listener.nfsserverprovisioner.enabled: "false"` and define the remaining `listener.cache.*` values as described below:
 
@@ -24,7 +24,7 @@ To use your own external NFS server:
           path: /var/nfs/data/ # External NFS server directory or file system to be mounted
     ```
 
-1.  Apply the new configuration by performing a Helm upgrade. To do so execute the command [used to install Codacy](../../index.md#helm-upgrade):
+1.  Apply the new configuration by performing a Helm upgrade. To do so execute the command [used to install Codacy](../index.md#helm-upgrade):
 
     !!! important
         **If you're using MicroK8s** you must use the file `values-microk8s.yaml` together with the file `values-production.yaml`.

--- a/docs/configuration/caching.md
+++ b/docs/configuration/caching.md
@@ -18,7 +18,7 @@ To use your own external NFS server:
         enabled: false
       cache:
         name: listener-cache
-        path: /data"
+        path: /data
         nfs:
           server: <NFS_SERVER_IP> # IP address of the external NFS server
           path: /var/nfs/data/ # External NFS server directory or file system to be mounted

--- a/docs/configuration/caching.md
+++ b/docs/configuration/caching.md
@@ -1,5 +1,5 @@
 ---
-description: <!--TODO-->
+description: Configure Codacy Self-hosted to use an external NFS server to improve the performance of the cloned repository cache.
 ---
 
 # Caching

--- a/docs/configuration/caching.md
+++ b/docs/configuration/caching.md
@@ -1,0 +1,5 @@
+---
+description: <!--TODO-->
+---
+
+# Caching

--- a/docs/configuration/caching.md
+++ b/docs/configuration/caching.md
@@ -10,18 +10,18 @@ To use your own external NFS server:
 
 1.  Edit the file `values-production.yaml` that you [used to install Codacy](../../index.md#helm-upgrade).
 
-1.  Set `nfsserverprovisioner.enabled: "false"` and define the remaining values as described below:
+1.  Set `listener.nfsserverprovisioner.enabled: "false"` and define the remaining `listener.cache.*` values as described below:
 
     ```yaml
-    nfsserverprovisioner:
-      enabled: "false"
-
-    cache:
-      name: "listener-cache"
-      path: "/data"
-      nfs:
-        server: "<NFS_SERVER_IP>" # The IP address of the external NFS server
-        path: "/var/nfs/data/" # External NFS server directory or file system to be mounted
+    listener:
+      nfsserverprovisioner:
+        enabled: false
+      cache:
+        name: listener-cache
+        path: /data"
+        nfs:
+          server: <NFS_SERVER_IP> # IP address of the external NFS server
+          path: /var/nfs/data/ # External NFS server directory or file system to be mounted
     ```
 
 1.  Apply the new configuration by performing a Helm upgrade. To do so execute the command [used to install Codacy](../../index.md#helm-upgrade):

--- a/docs/configuration/caching.md
+++ b/docs/configuration/caching.md
@@ -3,3 +3,37 @@ description: <!--TODO-->
 ---
 
 # Caching
+
+Codacy Self-hosted includes a built-in NFS server provisioner that deploys a shared volume to cache the cloned repository files while they're being analyzed by each tool. However, if you're dealing with big repositories or a high volume of analysis, using an NFS server external to the cluster will improve the performance of the cache.
+
+To use your own external NFS server:
+
+1.  Edit the file `values-production.yaml` that you [used to install Codacy](../../index.md#helm-upgrade).
+
+1.  Set `nfsserverprovisioner.enabled: "false"` and define the remaining values as described below:
+
+    ```yaml
+    nfsserverprovisioner:
+      enabled: "false"
+
+    cache:
+      name: "listener-cache"
+      path: "/data"
+      nfs:
+        server: "<NFS_SERVER_IP>" # The IP address of the external NFS server
+        path: "/var/nfs/data/" # External NFS server directory or file system to be mounted
+    ```
+
+1.  Apply the new configuration by performing a Helm upgrade. To do so execute the command [used to install Codacy](../../index.md#helm-upgrade):
+
+    !!! important
+        **If you're using MicroK8s** you must use the file `values-microk8s.yaml` together with the file `values-production.yaml`.
+        
+        To do this, uncomment the last line before running the `helm upgrade` command below.
+
+    ```bash
+    helm upgrade (...options used to install Codacy...) \
+                 --version {{ version }} \
+                 --values values-production.yaml \
+                 # --values values-microk8s.yaml
+    ```

--- a/docs/configuration/integrations/bitbucket-server.md
+++ b/docs/configuration/integrations/bitbucket-server.md
@@ -66,15 +66,15 @@ After creating the Bitbucket Server application link, you must configure it on C
 
     ```yaml
     bitbucketEnterprise:
-       enabled: "true"
-       login: "true" # Show login button for Bitbucket Server
-       hostname: "bitbucket.example.com" # Hostname of your Bitbucket Server instance
-       protocol: "https" # Protocol of your Bitbucket Server instance
-       port: 7990 # Port of your Bitbucket Server instance
-       consumerKey: "" # Generated when creating the Bitbucket Server application link
-       consumerPublicKey: "" # Generated when creating the Bitbucket Server application link
-       consumerPrivateKey: "" # Generated when creating the Bitbucket Server application link
-       contextPath: "" # Context path of your Bitbucket Server, if configured
+      enabled: "true"
+      login: "true" # Show login button for Bitbucket Server
+      hostname: "bitbucket.example.com" # Hostname of your Bitbucket Server instance
+      protocol: "https" # Protocol of your Bitbucket Server instance
+      port: 7990 # Port of your Bitbucket Server instance
+      consumerKey: "" # Generated when creating the Bitbucket Server application link
+      consumerPublicKey: "" # Generated when creating the Bitbucket Server application link
+      consumerPrivateKey: "" # Generated when creating the Bitbucket Server application link
+      contextPath: "" # Context path of your Bitbucket Server, if configured
     ```
 
 3.  Apply the new configuration by performing a Helm upgrade. To do so execute the command [used to install Codacy](../../index.md#helm-upgrade):

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,7 @@ nav:
           - configuration/integrations/bitbucket-cloud.md
           - configuration/integrations/bitbucket-server.md
           - configuration/integrations/email.md
+      - configuration/caching.md
       - configuration/monitoring.md
       - configuration/logging.md
   - "Maintenance and operations":


### PR DESCRIPTION
Adds instructions on how to configure Codacy Self-hosted to mount an NFS volume on an external server.

### :eyes: Live preview
https://feature-update-chart--docs-codacy.netlify.app/chart/configuration/caching/