### PR TITLE
fix: deploy to k8s 1.22

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/base@6.1.4
+  codacy: codacy/base@9.0.1
   slack: circleci/slack@3.4.2
 
 references:
@@ -515,11 +515,11 @@ workflows:
           requires:
             - validate_dev_cluster
       - codacy/microk8s_install:
-          name: install_k8s-1.16_helm-3.2
+          name: install_k8s-1.21_helm-3.9_unstable
           helm_repo: "https://charts.codacy.com/unstable"
           chart_version: $(cat .version)
-          microk8s_channel: "1.16/stable"
-          helm_version: "v3.2.1"
+          microk8s_channel: "1.21/stable"
+          helm_version: "v3.9.0"
           helm_timeout: 1200
           context: CodacyDocker
           docker_username: $DOCKER_USER
@@ -605,68 +605,13 @@ workflows:
           context: CodacyDO
           requires:
             - setup_release_db_values
-      - codacy/microk8s_install:
-          name: install_k8s-1.15_helm-3.2
-          helm_repo: "https://charts.codacy.com/incubator"
-          chart_version: $(cat .version)
-          microk8s_channel: "1.15/stable"
-          helm_version: "v3.2.1"
-          helm_timeout: 1200
-          context: CodacyDocker
-          docker_username: $DOCKER_USER
-          docker_password: $DOCKER_PASS
-          <<: *helm_values
-          requires:
-            - helm_push_incubator
 
       - codacy/microk8s_install:
-          name: install_k8s-1.16_helm-3.2
-          helm_repo: "https://charts.codacy.com/incubator"
-          chart_version: $(cat .version)
-          microk8s_channel: "1.16/stable"
-          helm_version: "v3.2.1"
-          helm_timeout: 1200
-          context: CodacyDocker
-          docker_username: $DOCKER_USER
-          docker_password: $DOCKER_PASS
-          <<: *helm_values
-          requires:
-            - helm_push_incubator
-
-      - codacy/microk8s_install:
-          name: install_k8s-1.17_helm-3.2
-          helm_repo: "https://charts.codacy.com/incubator"
-          chart_version: $(cat .version)
-          microk8s_channel: "1.17/stable"
-          helm_version: "v3.2.1"
-          helm_timeout: 1200
-          context: CodacyDocker
-          docker_username: $DOCKER_USER
-          docker_password: $DOCKER_PASS
-          <<: *helm_values
-          requires:
-            - helm_push_incubator
-
-      - codacy/microk8s_install:
-          name: install_k8s-1.18_helm-3.2
-          helm_repo: "https://charts.codacy.com/incubator"
-          chart_version: $(cat .version)
-          microk8s_channel: "1.18/stable"
-          helm_version: "v3.2.1"
-          helm_timeout: 1200
-          context: CodacyDocker
-          docker_username: $DOCKER_USER
-          docker_password: $DOCKER_PASS
-          <<: *helm_values
-          requires:
-            - helm_push_incubator
-
-      - codacy/microk8s_install:
-          name: install_k8s-1.19_helm-3.2
+          name: install_k8s-1.19_helm-3.9
           helm_repo: "https://charts.codacy.com/incubator"
           chart_version: $(cat .version)
           microk8s_channel: "1.19/stable"
-          helm_version: "v3.2.1"
+          helm_version: "v3.9.0"
           helm_timeout: 1200
           context: CodacyDocker
           docker_username: $DOCKER_USER
@@ -676,11 +621,11 @@ workflows:
             - helm_push_incubator
 
       - codacy/microk8s_install:
-          name: install_k8s-1.20_helm-3.2
+          name: install_k8s-1.20_helm-3.9
           helm_repo: "https://charts.codacy.com/incubator"
           chart_version: $(cat .version)
           microk8s_channel: "1.20/stable"
-          helm_version: "v3.2.1"
+          helm_version: "v3.9.0"
           helm_timeout: 1200
           context: CodacyDocker
           docker_username: $DOCKER_USER
@@ -690,11 +635,25 @@ workflows:
             - helm_push_incubator
 
       - codacy/microk8s_install:
-          name: install_k8s-1.21_helm-3.2
+          name: install_k8s-1.21_helm-3.9
           helm_repo: "https://charts.codacy.com/incubator"
           chart_version: $(cat .version)
           microk8s_channel: "1.21/stable"
-          helm_version: "v3.2.1"
+          helm_version: "v3.9.0"
+          helm_timeout: 1200
+          context: CodacyDocker
+          docker_username: $DOCKER_USER
+          docker_password: $DOCKER_PASS
+          <<: *helm_values
+          requires:
+            - helm_push_incubator
+
+      - codacy/microk8s_install:
+          name: install_k8s-1.22_helm-3.9
+          helm_repo: "https://charts.codacy.com/incubator"
+          chart_version: $(cat .version)
+          microk8s_channel: "1.22/stable"
+          helm_version: "v3.9.0"
           helm_timeout: 1200
           context: CodacyDocker
           docker_username: $DOCKER_USER
@@ -728,13 +687,10 @@ workflows:
             - test_e2e
             - test_api
             - test_apiv3
-            - install_k8s-1.15_helm-3.2
-            - install_k8s-1.16_helm-3.2
-            - install_k8s-1.17_helm-3.2
-            - install_k8s-1.18_helm-3.2
-            - install_k8s-1.19_helm-3.2
-            - install_k8s-1.20_helm-3.2
-            - install_k8s-1.21_helm-3.2
+            - install_k8s-1.19_helm-3.9
+            - install_k8s-1.20_helm-3.9
+            - install_k8s-1.21_helm-3.9
+            - install_k8s-1.22_helm-3.9
       - manual_solutions_eng_hold:
           type: approval
           context: CodacyDO
@@ -743,13 +699,10 @@ workflows:
             - test_e2e
             - test_api
             - test_apiv3
-            - install_k8s-1.15_helm-3.2
-            - install_k8s-1.16_helm-3.2
-            - install_k8s-1.17_helm-3.2
-            - install_k8s-1.18_helm-3.2
-            - install_k8s-1.19_helm-3.2
-            - install_k8s-1.20_helm-3.2
-            - install_k8s-1.21_helm-3.2
+            - install_k8s-1.19_helm-3.9
+            - install_k8s-1.20_helm-3.9
+            - install_k8s-1.21_helm-3.9
+            - install_k8s-1.22_helm-3.9
       - set_chart_version_release:
           context: CodacyDO
           requires:

--- a/codacy/requirements-dev.yaml
+++ b/codacy/requirements-dev.yaml
@@ -19,7 +19,7 @@ dependencies:
     global.metricsdb.create, global.filestoredb.create, global.jobsdb.create
 
 - name: log-router
-  version: 0.6.3
+  version: 0.6.4
   repository: https://charts.codacy.com/external
   condition: fluentdoperator.enabled
   alias: fluentdoperator

--- a/codacy/requirements.yaml
+++ b/codacy/requirements.yaml
@@ -19,7 +19,7 @@ dependencies:
     global.metricsdb.create, global.filestoredb.create, global.jobsdb.create
 
 - name: log-router
-  version: 0.6.3
+  version: 0.6.4
   repository: https://charts.codacy.com/external
   condition: fluentdoperator.enabled
   alias: fluentdoperator

--- a/codacy/values.yaml
+++ b/codacy/values.yaml
@@ -248,9 +248,12 @@ codacy-ingress:
       nginx.ingress.kubernetes.io/use-regex: "true"
     extraPaths:
       - backend:
-          serviceName: codacy-crow
-          servicePort: http
+          service:
+            name: codacy-crow
+            port:
+              name: http
         path: /monitoring
+        pathType: ImplementationSpecific
 
 ## If you set this to be enabled: true, you must clean up the fluentd job yourself
 fluentdoperator:

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,7 +49,7 @@ Install Codacy on an existing cluster using our Helm chart:
         !!! important
             **If you're using MicroK8s** you don't need to install kubectl because you will execute all `kubectl` commands as `microk8s.kubectl` commands instead. To simplify this, [check how to create an alias](infrastructure/microk8s-quickstart.md#notes-on-installing-codacy) for `kubectl`.
 
-    -   [Helm](https://helm.sh/docs/intro/install/) version >= 3.2
+    -   [Helm](https://helm.sh/docs/intro/install/) version >= 3.9
 
 2.  Create a cluster namespace called `codacy` that will group all resources related to Codacy.
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -22,8 +22,8 @@ The cluster running Codacy must satisfy the following requirements:
 
 -   The infrastructure hosting the cluster must be provisioned with the hardware and networking requirements described below
 -   The orchestration platform managing the cluster must be one of:
-    -   [Kubernetes](https://kubernetes.io/) **version 1.15.\*** to **1.20.\*** (1.20 recommended)
-    -   [MicroK8s](https://microk8s.io/) **version 1.15.\*** to **1.19.\*** (1.19 recommended)
+    -   [Kubernetes](https://kubernetes.io/) **version 1.19.\*** to **1.21.\*** (1.21 recommended)
+    -   [MicroK8s](https://microk8s.io/) **version 1.19.\*** to **1.21.\*** (1.19 recommended)
 -   The [NGINX Ingress controller](https://github.com/kubernetes/ingress-nginx) must be installed and correctly set up in the cluster
 
 ### Cluster networking requirements


### PR DESCRIPTION
This PR introduces some version updates and some compatibility fixes for more recent versions of k8s, namely:
- Bumps helm version used in testing to latest stable.
- Bumps orb version to add fixes that make microk8s deployment in ci less flaky.
- Test by default using the current stable version of helm and k8s 1.21.
- Add tests with microk8s 1.22, as a first step towards officially supporting this version.
- Drops support for deprecated k8s versions, those earlier than 1.19 (already not supported by cloud providers)
- Updates version information on our docs about k8s and helm.