### PR TITLE
fix: Update minio storage persistence to match value in cluster

### DIFF
--- a/codacy/values-production.yaml
+++ b/codacy/values-production.yaml
@@ -328,7 +328,7 @@ rabbitmq-ha:
 minio:
   persistence:
     enabled: true
-    size: 20Gi
+    size: 40Gi
   resources:
     requests:
       memory: 1.5Gi

--- a/codacy/values.yaml
+++ b/codacy/values.yaml
@@ -327,7 +327,7 @@ postgres:
 minio:
   fullnameOverride: codacy-minio
   persistence:
-    size: 20Gi
+    size: 40Gi
   minioConfig:
     region: "eu-west-1"
   buckets:


### PR DESCRIPTION
This change is just to put what is currently configured live, as code, since there was a mismatch.

This prevented the deployment to complete, because helm was trying to patch a PersistentVolumeClaim with a value smaller than what's currently there (so 40Gi configured to 20Gi as code) and Kubernetes does not allow that.

The screenshot shows the current values we have live, which as you can confirm match the change in this PR

![image](https://user-images.githubusercontent.com/92342193/184917983-b40ae116-5e78-42d5-95b9-6f9a57189d48.png)
