### PR TITLE
bump: Upgrade terraform providers and k8s cluster version

### DIFF
--- a/.do/db-cluster/config.tf
+++ b/.do/db-cluster/config.tf
@@ -11,11 +11,11 @@ terraform {
   required_providers {
     digitalocean = {
       source = "digitalocean/digitalocean"
-      version = "~> 1.22.2"
+      version = "~> 2.22.1"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"
-      version = "~> 1.13.1"
+      version = "~> 2.12.1"
     }
   }
 }

--- a/.do/k8s-cluster/variables.tf
+++ b/.do/k8s-cluster/variables.tf
@@ -5,7 +5,7 @@
 variable "k8s_version" {
   description = "Kubernetes version. See available versions with `doctl kubernetes options versions`"
   type        = string
-  default     = "1.17.11-do.0"
+  default     = "1.22.12-do.0"
 }
 
 variable "node_type" {


### PR DESCRIPTION
Also bumped the providers version on DO files.

This was not possible to do on k8s files without further changes, because the current configuration was not compatible.

Want to discuss of those required changes are worth doing right now.