### PR TITLE
doc: Troubleshoot upgrade with new MinIO PVC size DOCS-449

### DIFF
--- a/docs/troubleshoot/troubleshoot.md
+++ b/docs/troubleshoot/troubleshoot.md
@@ -127,3 +127,22 @@ If the **Code patterns** page of your repositories doesn't list a new tool that 
 ```bash
 curl -X POST localhost:9000/api/v1/engine/initialize
 ```
+
+## Upgrade failed: cannot patch "codacy-minio"
+
+If you download and use an updated `values-production.yaml` file while upgrading to [Codacy Self-hosted 9.0.0](/release-notes/self-hosted/self-hosted-v9.0.0/), you'll get the following error:
+
+> Error: UPGRADE FAILED: cannot patch "codacy-minio" with kind PersistentVolumeClaim: persistentvolumeclaims "codacy-minio" is forbidden: only dynamically provisioned pvc can be resized and the storageclass that provisions the pvc must support resize
+
+This happens because [we updated the MinIO PVC size](https://github.com/codacy/chart/commit/40a158f8b6f62a6f90387060b86fe1dd8d008ed5). As a workaround, you can either:
+
+-   Reset the PVC size back to the original value of 20Gi on your `values.yaml` file:
+
+    ```yaml
+    minio:
+      fullnameOverride: codacy-minio
+      persistence:
+        size: 20Gi
+    ```
+
+-   [Uninstall your current version of Codacy](../maintenance/uninstall.md) and reinstall Codacy Self-hosted 9.0.0 directly. Your data won't be impacted by the uninstall since it's stored on the database.

--- a/docs/troubleshoot/troubleshoot.md
+++ b/docs/troubleshoot/troubleshoot.md
@@ -98,11 +98,7 @@ If the error persists:
 1.  Take note of the parameter `client_id` in the URL of the Bitbucket Cloud error page (for example, `r8QJDkkxj8unYfg4Bd`)
 2.  Check if the value of the parameter matches the value of the Client ID of your Bitbucket OAuth consumer
 
-## Codacy configuration
-
-The following sections help you troubleshoot the Codacy configuration.
-
-### Accessing the RabbitMQ dashboard
+## Accessing the RabbitMQ dashboard
 
 We use RabbitMQ for the internal message queue between our components.
 


### PR DESCRIPTION
Adds a troubleshooting section for the error "Upgrade failed: cannot patch "codacy-minio" while upgrading to Codacy Self-hosted 9.0.0 with an updated `codacy-production.yaml` file.

Fixes #754.

### :eyes: Live preview
https://github.com/codacy/chart/blob/doc/troubleshoot-minio-storage-DOCS-449/docs/troubleshoot/troubleshoot.md#upgrade-failed-cannot-patch-codacy-minio