### PR TITLE
doc: Update minimum supported PostgreSQL version to 11.16 PLUTO-150

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -96,7 +96,7 @@ The storage requirements recommended on the following table **depend mainly on t
 Codacy requires a database server to persist data that must satisfy the following requirements:
 
 -   The infrastructure hosting the database server must be provisioned with the hardware requirements described below
--   The DBMS server must be [PostgreSQL](https://www.postgresql.org/) **version 10.20**
+-   The DBMS server must be [PostgreSQL](https://www.postgresql.org/) **version 11.16**
 -   The PostgreSQL server must be configured to accept connections from the cluster
 -   The Codacy databases and a dedicated user must be created using the instructions below
 


### PR DESCRIPTION
Bumps the minimum supported PostgreSQL version. [See this comment](https://codacy.atlassian.net/browse/PLUTO-150?focusedCommentId=52593) for more context.

Relates to https://github.com/codacy/chart/pull/765.