### PR TITLE
doc: Update NGINX Ingress Controller install for K8s >=1.22 DOCS-521

### DIFF
--- a/docs/infrastructure/eks-quickstart.md
+++ b/docs/infrastructure/eks-quickstart.md
@@ -134,11 +134,22 @@ Install the NGINX Ingress Controller:
 
     If you wish to use a private load balancer or restrict the IP range for the provisioned load balancer edit the file and enable the required annotation and/or the corresponding setting where indicated.
 
-2.  Install the NGINX Ingress Controller:
+2.  Install the NGINX Ingress Controller.
+
+    **If you're using Kubernetes version <=1.21**, run:
 
     ```bash
     kubectl create namespace codacy
     helm upgrade --install --namespace codacy --version 1.39.0 codacy-nginx-ingress stable/nginx-ingress -f values-nginx.yaml
+    ```
+
+    **If you're using Kubernetes version 1.22 or later**, run:
+
+    ```
+    kubectl create namespace codacy
+    helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+    helm repo update
+    helm upgrade --install --namespace codacy --version 4.3.0 nginx-ingress ingress-nginx/ingress-nginx -f values-nginx.yaml
     ```
 
 ## Uninstalling the Amazon EKS cluster

--- a/docs/infrastructure/eks-quickstart.md
+++ b/docs/infrastructure/eks-quickstart.md
@@ -144,7 +144,7 @@ Install the NGINX Ingress Controller:
 ## Uninstalling the Amazon EKS cluster
 
 !!! warning
-If you proceed beyond this point you'll permanently delete and break things.
+    If you proceed beyond this point you'll permanently delete and break things.
 
 1.  Delete the Kubernetes cluster.
 


### PR DESCRIPTION
Adds updated instructions for installing the NGINX Ingress Controller when using Kubernetes 1.22 or later. 

### :eyes: Live preview

https://github.com/codacy/chart/blob/doc/update-nginx-install-DOCS-521/docs/infrastructure/eks-quickstart.md#5-install-the-nginx-ingress-controller