### PR TITLE
fix: Disable loki and promtail deprecated psp [REL-1308]

### DIFF
--- a/docs/values-files/values-loki.yaml
+++ b/docs/values-files/values-loki.yaml
@@ -19,6 +19,8 @@ persistence:
 table_manager:
   retention_deletes_enabled: true
   retention_period: 72h
+rbac:
+  pspEnabled: false
 grafana:
   datasources:
     enabled: true

--- a/docs/values-files/values-promtail.yaml
+++ b/docs/values-files/values-promtail.yaml
@@ -10,3 +10,5 @@ config:
       minbackoff: 2s
       maxbackoff: 20s
       maxretries: 5
+rbac:
+  pspEnabled: false


### PR DESCRIPTION
PodSecurityPolicy was deprecated in k8s 1.25 [REL-1308](https://codacy.atlassian.net/browse/REL-1308), therefore we need to explicitly disable them for loki and promtail.

[REL-1308]: https://codacy.atlassian.net/browse/REL-1308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ