### PR TITLE
doc: Update v11 documentation DOCS-570

### DIFF
--- a/docs/infrastructure/microk8s-quickstart.md
+++ b/docs/infrastructure/microk8s-quickstart.md
@@ -45,6 +45,12 @@ Install MicroK8s on the machine:
     microk8s.status --wait-ready
     ```
 
+4.  If you're running MicroK8s using a single node, disable high-availability clustering for improved performance:
+
+    ```bash
+    microk8s.disable ha-cluster
+    ```
+
 ## 3. Configuring MicroK8s
 
 Now that MicroK8s is running on the machine we can proceed to enabling the necessary addons:

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -22,7 +22,7 @@ The cluster running Codacy must satisfy the following requirements:
 
 -   The infrastructure hosting the cluster must be provisioned with the hardware and networking requirements described below
 -   The orchestration platform managing the cluster must be one of:
-    -   [Kubernetes](https://kubernetes.io/) **version 1.22.\*** to **1.23.\*** (1.23 recommended)
+    -   [Kubernetes](https://kubernetes.io/) **version 1.22.\*** to **1.24.\*** (1.23 recommended)
     -   [MicroK8s](https://microk8s.io/) **version 1.19.\***
 -   The [NGINX Ingress controller](https://github.com/kubernetes/ingress-nginx) must be installed and correctly set up in the cluster
 


### PR DESCRIPTION
* Updates microk8s installation instructions with step on disabling the high-availability option
* Extends supported k8s versions to 1.24