### PR TITLE
doc: SH 13 documentation updates

### DIFF
--- a/docs/maintenance/database.md
+++ b/docs/maintenance/database.md
@@ -42,7 +42,7 @@ PGPASSWORD=$DB_PASSWORD pg_dump -h $SRC_HOSTNAME -p $SRC_HOSTPORT -U $DB_USER --
 
 This will dump the file with the `.dump` extension into the `/tmp` folder.
 
-[For more information and additional options, please check the official documentation.](https://www.postgresql.org/docs/10/app-pgdump.html)
+[For more information and additional options, please check the official documentation.](https://www.postgresql.org/docs/11/app-pgdump.html)<!-- TODO DOCS-612 Confirm link should be updated to the recommended version -->
 
 ### pg_restore
 
@@ -57,7 +57,7 @@ With the custom format from `pg_dump` (by using `-Fc`) we can now invoke `pg_res
 !!! note
     If you run into any problems while restoring, make sure that you have the database created in that Postgres instance (e.g. before restoring the jobs database the Postgres instance should have an empty database called `jobs` created there).
 
-For more information and additional options, please check the [official documentation](https://www.postgresql.org/docs/9.6/app-pgrestore.html).
+For more information and additional options, please check the [official documentation](https://www.postgresql.org/docs/11/app-pgrestore.html).<!-- TODO DOCS-612 Confirm link should be updated to the recommended version -->
 
 ## Sample script
 

--- a/docs/maintenance/database.md
+++ b/docs/maintenance/database.md
@@ -42,7 +42,7 @@ PGPASSWORD=$DB_PASSWORD pg_dump -h $SRC_HOSTNAME -p $SRC_HOSTPORT -U $DB_USER --
 
 This will dump the file with the `.dump` extension into the `/tmp` folder.
 
-[For more information and additional options, please check the official documentation.](https://www.postgresql.org/docs/11/app-pgdump.html)<!-- TODO DOCS-612 Confirm link should be updated to the recommended version -->
+[For more information and additional options, please check the official documentation.](https://www.postgresql.org/docs/12/app-pgdump.html)
 
 ### pg_restore
 
@@ -57,7 +57,7 @@ With the custom format from `pg_dump` (by using `-Fc`) we can now invoke `pg_res
 !!! note
     If you run into any problems while restoring, make sure that you have the database created in that Postgres instance (e.g. before restoring the jobs database the Postgres instance should have an empty database called `jobs` created there).
 
-For more information and additional options, please check the [official documentation](https://www.postgresql.org/docs/11/app-pgrestore.html).<!-- TODO DOCS-612 Confirm link should be updated to the recommended version -->
+For more information and additional options, please check the [official documentation](https://www.postgresql.org/docs/12/app-pgrestore.html).
 
 ## Sample script
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -99,7 +99,7 @@ The storage requirements recommended on the following table **depend mainly on t
 Codacy requires a database server to persist data that must satisfy the following requirements:
 
 -   The infrastructure hosting the database server must be provisioned with the hardware requirements described below
--   The DBMS server must be [PostgreSQL](https://www.postgresql.org/) **version 11.20**<!- TODO DOCS-612 Confirm version -->
+-   The DBMS server must be [PostgreSQL](https://www.postgresql.org/) **version 11.20** or **version 12.\*** (12.* recommended)
 -   The PostgreSQL server must be configured to accept connections from the cluster
 -   The Codacy databases and a dedicated user must be created using the instructions below
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -22,7 +22,7 @@ The cluster running Codacy must satisfy the following requirements:
 
 -   The infrastructure hosting the cluster must be provisioned with the hardware and networking requirements described below
 -   The orchestration platform managing the cluster must be one of:
-    -   [Kubernetes](https://kubernetes.io/) **version 1.22.\*** to **1.25.\*** (1.23 recommended)
+    -   [Kubernetes](https://kubernetes.io/) **version 1.22.\*** to **1.26.\*** (1.23 recommended)<!-- TODO DOCS-612 Confirm recommended version -->
     -   [MicroK8s](https://microk8s.io/) **version 1.19.\***
 -   The [NGINX Ingress controller](https://github.com/kubernetes/ingress-nginx) must be installed and correctly set up in the cluster
 
@@ -99,7 +99,7 @@ The storage requirements recommended on the following table **depend mainly on t
 Codacy requires a database server to persist data that must satisfy the following requirements:
 
 -   The infrastructure hosting the database server must be provisioned with the hardware requirements described below
--   The DBMS server must be [PostgreSQL](https://www.postgresql.org/) **version 11.20**
+-   The DBMS server must be [PostgreSQL](https://www.postgresql.org/) **version 11.20**<!- TODO DOCS-612 Confirm version -->
 -   The PostgreSQL server must be configured to accept connections from the cluster
 -   The Codacy databases and a dedicated user must be created using the instructions below
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -22,7 +22,7 @@ The cluster running Codacy must satisfy the following requirements:
 
 -   The infrastructure hosting the cluster must be provisioned with the hardware and networking requirements described below
 -   The orchestration platform managing the cluster must be one of:
-    -   [Kubernetes](https://kubernetes.io/) **version 1.22.\*** to **1.26.\*** (1.23 recommended)<!-- TODO DOCS-612 Confirm recommended version -->
+    -   [Kubernetes](https://kubernetes.io/) **version 1.22.\*** to **1.26.\*** (1.23 recommended)
     -   [MicroK8s](https://microk8s.io/) **version 1.19.\***
 -   The [NGINX Ingress controller](https://github.com/kubernetes/ingress-nginx) must be installed and correctly set up in the cluster
 


### PR DESCRIPTION
* Updates supported Kubernetes versions to `1.22.* to 1.26.* (1.23 recommended)`
* Updates supported PostgreSQL versions to `version 11.20 or version 12.* (12.* recommended)`
* Updates links to external PostgreSQL documentation to version 12 (recommended version)