### PR TITLE
infra: upgrade grafana loki

### DIFF
--- a/.do/Makefile
+++ b/.do/Makefile
@@ -119,7 +119,7 @@ deploy_monitoring: #set_cluster_context
 	-kubectl create namespace monitoring
 
 	helm upgrade --install --atomic --timeout 600s loki grafana/loki \
-	  --version 2.14.1 --namespace monitoring --values ../docs/values-files/values-loki.yaml
+	  --version 2.16.0 --namespace monitoring --values ../docs/values-files/values-loki.yaml
 
 	helm upgrade --install --atomic --timeout 600s promtail grafana/promtail \
 	  --version 2.2.0 --namespace monitoring --values values-promtail.yaml

--- a/docs/configuration/monitoring.md
+++ b/docs/configuration/monitoring.md
@@ -83,7 +83,7 @@ helm repo add grafana https://grafana.github.io/helm-charts
 kubectl create namespace monitoring
 
 helm upgrade --install --atomic --timeout 600s loki grafana/loki \
-  --version 2.14.1 --namespace monitoring --values values-loki.yaml
+  --version 2.16.0 --namespace monitoring --values values-loki.yaml
 ```
 
 ### 3. Installing Promtail

--- a/docs/values-files/values-loki.yaml
+++ b/docs/values-files/values-loki.yaml
@@ -1,3 +1,5 @@
+minio:
+  enabled: true
 resources:
   limits:
     cpu: 1
@@ -5,22 +7,16 @@ resources:
   requests:
     cpu: 500m
     memory: 500Mi
-config:
+loki:
   limits_config:
     cardinality_limit: 200000
     ingestion_rate_mb: 15
     ingestion_burst_size_mb: 20
-serviceMonitor:
-  enabled: true
-persistence:
-  enabled: true
-  size: 100Gi # adjust persistence volume size if needed
-  #storageClassName: <--- storage class ---> 
-table_manager:
-  retention_deletes_enabled: true
-  retention_period: 72h
+monitoring:
+  serviceMonitor:
+    enabled: true
+  table_manager:
+    retention_deletes_enabled: true
+    retention_period: 72h
 rbac:
   pspEnabled: false
-grafana:
-  datasources:
-    enabled: true


### PR DESCRIPTION
The chart version was causing some issues as well as the config file that we were using for said release. The result of this change is the logs being displayed in Grafana (example was obtained by port-forwarding the grafana service and checking the datasource for loki) 

<img width="1502" height="777" alt="image" src="https://github.com/user-attachments/assets/8f7e6fc5-2eb3-492d-bc21-9216ac659a4a" />


<img width="1502" height="777" alt="Screenshot 2026-01-15 at 12 06 47" src="https://github.com/user-attachments/assets/0ed284b4-e046-4621-b8dc-b37c613ab166" />
